### PR TITLE
Skip retained messages while testing

### DIFF
--- a/tests/test_discoverable.py
+++ b/tests/test_discoverable.py
@@ -128,6 +128,10 @@ def test_str(discoverable: Discoverable[EntityInfo]):
 # Define a callback function to be invoked when we receive a message on the topic
 def message_callback(client: Client, userdata, message: MQTTMessage, tmp=None):
     logging.info("Received %s", message)
+    # If the broker is `dirty` and contains messages send by other test functions, skip these retained messages
+    if message.retain:
+        logging.warn("Skipping retained message")
+        return
     payload = message.payload.decode()
     assert "test" in payload
     userdata.set()


### PR DESCRIPTION
# Description
Try to fix the following test error: https://github.com/unixorn/ha-mqtt-discovery/actions/runs/4250691876/jobs/7392103433
Since the broker is not re-initialized between one test function and the next, when we subscribe to it we risk reading `retained` messages from previous test invocations, instead of the _fresh_ new message we send as part of the test.

# License Acceptance
- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [ ] New feature
- [x] Test updates
- [ ] Text cleanups/updates


# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
