### PR TITLE
Rename repo to ha-mqtt-discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ha-mqtt-discoverable
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![License](https://img.shields.io/github/license/unixorn/ha-mqtt-discovery.svg)](https://opensource.org/license/apache-2-0/)
-[![GitHub last commit (branch)](https://img.shields.io/github/last-commit/unixorn/ha-mqtt-discovery/main.svg)](https://github.com/unixorn/ha-mqtt-discovery)
+[![License](https://img.shields.io/github/license/unixorn/ha-mqtt-discoverable.svg)](https://opensource.org/license/apache-2-0/)
+[![GitHub last commit (branch)](https://img.shields.io/github/last-commit/unixorn/ha-mqtt-discoverable/main.svg)](https://github.com/unixorn/ha-mqtt-discoverable)
 [![Downloads](https://static.pepy.tech/badge/ha-mqtt-discoverable)](https://pepy.tech/project/ha-mqtt-discoverable)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
@@ -194,8 +194,8 @@ Usage: `hmd create device --device-name coyote --device-id 8675309 --mqtt-user H
 
 ## Contributors
 
-<a href="https://github.com/unixorn/ha-mqtt-discovery/graphs/contributors">
-  <img src="https://contributors-img.web.app/image?repo=unixorn/ha-mqtt-discovery" />
+<a href="https://github.com/unixorn/ha-mqtt-discoverable/graphs/contributors">
+  <img src="https://contributors-img.web.app/image?repo=unixorn/ha-mqtt-discoverable" />
 </a>
 
 Made with [contributors-img](https://contributors-img.web.app).


### PR DESCRIPTION
# Description

- Rename repo to ha-mqtt-discoverable so it matches the module name.
- Change badge links to match new repo name

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [ ] New feature
- [ ] Test updates
- [x] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have confirmed that any links added or updated in my PR are valid.
