### PR TITLE
Feat: Add new entity type `device trigger`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The following Home Assistant entities are currently implemented:
 - Binary sensor
 - Switch
 - Button
+- Device trigger
 
 ### Binary sensor
 
@@ -128,7 +129,7 @@ From the [Home Assistant documentation](https://developers.home-assistant.io/doc
 A device is automatically created when an entity defines its `device` property.
 A device will be matched up with an existing device via supplied identifiers or connections, like serial numbers or MAC addresses.
 
-#### Usage
+### Usage
 
 The following example create a device, by associating multiple sensors to the same `DeviceInfo` instance.
 
@@ -165,6 +166,34 @@ door_sensor = BinarySensor(settings)
 door_sensor.on()
 
 # The two sensors should be visible inside Home Assistant under the device `My device`
+```
+
+### Device trigger
+
+The following example creates a device trigger and generates a trigger event:
+
+#### Usage
+```py
+from ha_mqtt_discoverable import Settings
+from ha_mqtt_discoverable.sensors import DeviceInfo, DeviceTriggerInfo, DeviceTrigger
+
+# Configure the required parameters for the MQTT broker
+mqtt_settings = Settings.MQTT(host="localhost")
+
+# Define the device. At least one of `identifiers` or `connections` must be supplied
+device_info = DeviceInfo(name="My device", identifiers="device_id")
+
+# Associate the sensor with the device via the `device` parameter
+trigger_into = DeviceTriggerInfo(name="MyTrigger", type="button_press", subtype="button_1", unique_id="my_device_trigger", device=device_info)
+
+settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
+
+# Instantiate the device trigger
+mytrigger = DeviceTrigger(settings)
+
+# Generate a device trigger event, publishing an MQTT message that gets picked up by HA
+# Optionally include a payload as part of the event
+mytrigger.trigger("My custom payload")
 ```
 
 ## Contributing

--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -678,10 +678,10 @@ wrote_configuration: {self.wrote_configuration}
         self.mqtt_client.loop_start()
 
     def _state_helper(
-        self, state: Optional[str], topic: Optional[str] = None
+        self, state: Optional[str], topic: Optional[str] = None, retain=True
     ) -> MQTTMessageInfo:
         """
-        Write a state to the given MQTT topic, return the result of client.publish()
+        Write a state to the given MQTT topic, returning the result of client.publish()
         """
         if not self.wrote_configuration:
             logger.debug("Writing sensor configuration")
@@ -695,7 +695,7 @@ wrote_configuration: {self.wrote_configuration}
             logger.debug(f"Debug is {self.debug}, skipping state write")
             return
 
-        message_info = self.mqtt_client.publish(topic, state, retain=True)
+        message_info = self.mqtt_client.publish(topic, state, retain=retain)
         logger.debug(f"Publish result: {message_info}")
         return message_info
 

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -4,14 +4,12 @@
 # Required to define a class itself as type https://stackoverflow.com/a/33533514
 from __future__ import annotations
 import logging
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
-from pydantic import Field
 from ha_mqtt_discoverable import (
     DeviceInfo,
     Discoverable,
     EntityInfo,
-    Settings,
     Subscriber,
 )
 

--- a/tests/test_device_trigger.py
+++ b/tests/test_device_trigger.py
@@ -30,7 +30,6 @@ def test_required_config():
     )
     settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
     trigger = DeviceTrigger(settings)
-    trigger.write_config()
     assert trigger is not None
 
 

--- a/tests/test_device_trigger.py
+++ b/tests/test_device_trigger.py
@@ -1,0 +1,43 @@
+import pytest
+from ha_mqtt_discoverable import DeviceInfo, Settings
+from ha_mqtt_discoverable.sensors import DeviceTrigger, DeviceTriggerInfo
+
+
+@pytest.fixture(name="device_trigger")
+def device_trigger() -> DeviceTrigger:
+    mqtt_settings = Settings.MQTT(host="localhost")
+    device_info = DeviceInfo(name="test", identifiers="id")
+    sensor_info = DeviceTriggerInfo(
+        name="test",
+        device=device_info,
+        type="button_press",
+        subtype="button_1",
+        unique_id="test",
+    )
+    settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
+    return DeviceTrigger(settings)
+
+
+def test_required_config():
+    mqtt_settings = Settings.MQTT(host="localhost")
+    device_info = DeviceInfo(name="test", identifiers="id")
+    sensor_info = DeviceTriggerInfo(
+        name="test",
+        device=device_info,
+        type="button_press",
+        subtype="button_1",
+        unique_id="test",
+    )
+    settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
+    trigger = DeviceTrigger(settings)
+    trigger.write_config()
+    assert trigger is not None
+
+
+def test_config_topic(device_trigger: DeviceTrigger):
+    config = device_trigger.generate_config()
+    assert config["topic"] == device_trigger.state_topic
+
+
+def test_trigger(device_trigger: DeviceTrigger):
+    device_trigger.trigger("my_payload")


### PR DESCRIPTION
# Description

- Add new type of discoverable entity: [device triggers](https://www.home-assistant.io/integrations/device_trigger.mqtt/)
- Update `README` with example

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [x] New feature
- [ ] Test updates
- [x] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
