### PR TITLE
feat(Discoverable): allow to publish attributes on an entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ mysensor = BinarySensor(settings)
 mysensor.on()
 mysensor.off()
 
+# You can also set custom attributes on the sensor via a Python dict
+mysensor.set_attributes({"my attribute": "awesome"})
+
 ```
 
 ### Switch

--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -771,7 +771,11 @@ wrote_configuration: {self.wrote_configuration}
         return self.mqtt_client.publish(self.config_topic, config_message, retain=True)
 
     def set_attributes(self, attributes: dict[str, Any]):
-        """Update the entity attributes"""
+        """Update the attributes of the entity
+
+        Args:
+            attributes: dictionary containing all the attributes that will be set for this entity
+        """
         # HA expects a JSON object in the attribute topic
         json_attributes = json.dumps(attributes)
         logger.debug("Updating attributes: %s", json_attributes)

--- a/tests/test_discoverable.py
+++ b/tests/test_discoverable.py
@@ -95,6 +95,7 @@ def test_mqtt_topics():
     assert d._entity_topic == "binary_sensor/test"
     assert d.config_topic == "homeassistant/binary_sensor/test/config"
     assert d.state_topic == "hmd/binary_sensor/test/state"
+    assert d.attributes_topic == "hmd/binary_sensor/test/attributes"
 
 
 def test_mqtt_topics_with_device():
@@ -108,6 +109,7 @@ def test_mqtt_topics_with_device():
     assert d._entity_topic == "binary_sensor/test_device/test"
     assert d.config_topic == "homeassistant/binary_sensor/test_device/test/config"
     assert d.state_topic == "hmd/binary_sensor/test_device/test/state"
+    assert d.attributes_topic == "hmd/binary_sensor/test_device/test/attributes"
 
 
 def test_generate_config(discoverable: Discoverable):
@@ -117,6 +119,7 @@ def test_generate_config(discoverable: Discoverable):
     assert device_config["name"] == "test"
     assert device_config["component"] == "binary_sensor"
     assert device_config["state_topic"] == "hmd/binary_sensor/test/state"
+    assert device_config["json_attributes_topic"] == "hmd/binary_sensor/test/attributes"
 
 
 def test_setup_client(discoverable: Discoverable):
@@ -324,3 +327,8 @@ def test_set_availability_wrong_config(discoverable: Discoverable):
     """A discoverable that has not set availability to manual cannot invoke the methods"""
     with pytest.raises(RuntimeError):
         discoverable.set_availability(True)
+
+
+def test_set_attributes(discoverable: Discoverable):
+    attributes = {"test attribute": "test"}
+    discoverable.set_attributes(attributes)


### PR DESCRIPTION
# Description
- Add `json_attributes_topic` to config object published to HA
- Add method `set_attributes()`, accepting a Python dict that will be set as attributes
- Update `README` with example

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [x] New feature
- [x] Test updates
- [ ] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
