### PR TITLE
Add Number entity type, and update README docs for Switch and Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ mqtt_settings = Settings.MQTT(host="localhost")
 # Information about the `text` entity
 text_info = TextInfo(name="test")
 
-settings = Settings(mqtt=mqtt_settings, entity=switch_info)
+settings = Settings(mqtt=mqtt_settings, entity=text_info)
 
 # To receive text updates from HA, define a callback function:
 def my_callback(client: Client, user_data, message: MQTTMessage):
@@ -218,7 +218,7 @@ mqtt_settings = Settings.MQTT(host="localhost")
 # Information about the `number` entity.
 number_info = NumberInfo(name="test", min=0, max=50, mode="slider", step=5)
 
-settings = Settings(mqtt=mqtt_settings, entity=switch_info)
+settings = Settings(mqtt=mqtt_settings, entity=number_info)
 
 # To receive number updates from HA, define a callback function:
 def my_callback(client: Client, user_data, message: MQTTMessage):
@@ -263,7 +263,7 @@ device_info = DeviceInfo(name="My device", identifiers="device_id")
 # `unique_id` must also be set, otherwise Home Assistant will not display the device in the UI
 motion_sensor_info = BinarySensorInfo(name="My motion sensor", device_class="motion", unique_id="my_motion_sensor", device=device_info)
 
-motion_settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
+motion_settings = Settings(mqtt=mqtt_settings, entity=motion_sensor_info)
 
 # Instantiate the sensor
 motion_sensor = BinarySensor(motion_settings)
@@ -302,7 +302,7 @@ device_info = DeviceInfo(name="My device", identifiers="device_id")
 # Associate the sensor with the device via the `device` parameter
 trigger_into = DeviceTriggerInfo(name="MyTrigger", type="button_press", subtype="button_1", unique_id="my_device_trigger", device=device_info)
 
-settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
+settings = Settings(mqtt=mqtt_settings, entity=trigger_info)
 
 # Instantiate the device trigger
 mytrigger = DeviceTrigger(settings)

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -33,8 +33,9 @@ class BinarySensorInfo(EntityInfo):
 
     component: str = "binary_sensor"
     off_delay: Optional[int] = None
-    """For sensors that only send on state updates (like PIRs),
-    this variable sets a delay in seconds after which the sensor’s state will be updated back to off."""
+    """For sensors that only send on state updates (like PIRs), this variable
+    sets a delay in seconds after which the sensor's state will be updated back
+    to off."""
     payload_off: str = "off"
     """Payload to send for the ON state"""
     payload_on: str = "on"
@@ -57,13 +58,13 @@ class SwitchInfo(EntityInfo):
     """Flag that defines if switch works in optimistic mode.
     Default: true if no state_topic defined, else false."""
     payload_off: str = "OFF"
-    """The payload that represents off state. If specified, will be used for both comparing
-    to the value in the state_topic (see value_template and state_off for details)
-    and sending as off command to the command_topic"""
+    """The payload that represents off state. If specified, will be used for
+    both comparing to the value in the state_topic (see value_template and
+    state_off for details) and sending as off command to the command_topic"""
     payload_on: str = "ON"
-    """The payload that represents on state. If specified, will be used for both comparing
-     to the value in the state_topic (see value_template and state_on for details)
-     and sending as on command to the command_topic."""
+    """The payload that represents on state. If specified, will be used for both
+    comparing to the value in the state_topic (see value_template and state_on
+    for details) and sending as on command to the command_topic."""
     retain: Optional[bool] = None
     """If the published message should have the retain flag on or not"""
     state_topic: Optional[str] = None
@@ -115,7 +116,8 @@ class NumberInfo(EntityInfo):
     """Flag that defines if switch works in optimistic mode.
     Default: true if no state_topic defined, else false."""
     payload_reset: Optional[str] = None
-    """A special payload that resets the state to None when received on the state_topic."""
+    """A special payload that resets the state to None when received on the
+    state_topic."""
     retain: Optional[bool] = None
     """If the published message should have the retain flag on or not"""
     state_topic: Optional[str] = None
@@ -186,7 +188,8 @@ class Sensor(Discoverable[SensorInfo]):
         self._state_helper(str(state))
 
 
-# Inherit the on and off methods from the BinarySensor class, changing only the documentation string
+# Inherit the on and off methods from the BinarySensor class, changing only the
+# documentation string
 class Switch(Subscriber[SwitchInfo], BinarySensor):
     """Implements an MQTT switch:
     https://www.home-assistant.io/integrations/switch.mqtt
@@ -217,8 +220,8 @@ class DeviceTrigger(Discoverable[DeviceTriggerInfo]):
     """
 
     def generate_config(self) -> dict[str, Any]:
-        """Publish a custom configuration:
-        since this entity does not provide a `state_topic`, HA expects a `topic` key in the config
+        """Publish a custom configuration: since this entity does not provide a
+        `state_topic`, HA expects a `topic` key in the config
         """
         config = super().generate_config()
         # Publish our `state_topic` as `topic`
@@ -251,8 +254,9 @@ class Text(Subscriber[TextInfo]):
             text(str): Value of the text configured for this entity
         """
         if not self._entity.min <= len(text) <= self._entity.max:
+            bound = f"[{self._entity.min}, {self._entity.max}]"
             raise RuntimeError(
-                f"Text is not within configured length boundaries [{self._entity.min}, {self._entity.max}]"
+                f"Text is not within configured length boundaries {bound}"
             )
 
         logger.info(f"Setting {self._entity.name} to {text} using {self.state_topic}")
@@ -266,14 +270,15 @@ class Number(Subscriber[NumberInfo]):
 
     def set_value(self, value: float) -> None:
         """
-        Update the numeric value. Raises an error if it is not within the acceptable range.
+        Update the numeric value. Raises an error if not within the acceptable range.
 
         Args:
             text(str): Value of the text configured for this entity
         """
         if not self._entity.min <= value <= self._entity.max:
+            bound = f"[{self._entity.min}, {self._entity.max}]"
             raise RuntimeError(
-                f"Value is not within configured boundaries [{self._entity.min}, {self._entity.max}]"
+                f"Value is not within configured boundaries {bound}"
             )
 
         logger.info(f"Setting {self._entity.name} to {value} using {self.state_topic}")

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -99,6 +99,34 @@ class TextInfo(EntityInfo):
     """If the published message should have the retain flag on or not"""
 
 
+class NumberInfo(EntityInfo):
+    """Information about the 'number' entity"""
+
+    component: str = "number"
+
+    max: float | int = 100
+    """The maximum value of the number (defaults to 100)"""
+    min: float | int = 1
+    """The maximum value of the number (defaults to 1)"""
+    mode: Optional[str] = None
+    """Control how the number should be displayed in the UI. Can be set to box
+    or slider to force a display mode."""
+    optimistic: Optional[bool] = None
+    """Flag that defines if switch works in optimistic mode.
+    Default: true if no state_topic defined, else false."""
+    payload_reset: Optional[str] = None
+    """A special payload that resets the state to None when received on the state_topic."""
+    retain: Optional[bool] = None
+    """If the published message should have the retain flag on or not"""
+    state_topic: Optional[str] = None
+    """The MQTT topic subscribed to receive state updates."""
+    step: Optional[float] = None
+    """Step value. Smallest acceptable value is 0.001. Defaults to 1.0."""
+    unit_of_measurement: Optional[str] = None
+    """Defines the unit of measurement of the sensor, if any. The
+    unit_of_measurement can be null."""
+
+
 class DeviceTriggerInfo(EntityInfo):
     """Information about the device trigger"""
 
@@ -229,3 +257,24 @@ class Text(Subscriber[TextInfo]):
 
         logger.info(f"Setting {self._entity.name} to {text} using {self.state_topic}")
         self._state_helper(str(text))
+
+
+class Number(Subscriber[NumberInfo]):
+    """Implements an MQTT number:
+    https://www.home-assistant.io/integrations/number.mqtt/
+    """
+
+    def set_value(self, value: float) -> None:
+        """
+        Update the numeric value. Raises an error if it is not within the acceptable range.
+
+        Args:
+            text(str): Value of the text configured for this entity
+        """
+        if not self._entity.min <= value <= self._entity.max:
+            raise RuntimeError(
+                f"Value is not within configured boundaries [{self._entity.min}, {self._entity.max}]"
+            )
+
+        logger.info(f"Setting {self._entity.name} to {value} using {self.state_topic}")
+        self._state_helper(value)

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,35 @@
+import pytest
+from ha_mqtt_discoverable import Settings
+from ha_mqtt_discoverable.sensors import Number, NumberInfo
+
+
+@pytest.fixture()
+def number() -> Number:
+    mqtt_settings = Settings.MQTT(host="localhost")
+    number_info = NumberInfo(name="test", min=5.0, max=90.0)
+    settings = Settings(mqtt=mqtt_settings, entity=number_info)
+    # Define empty callback
+    return Number(settings, lambda *_: None)
+
+
+def test_required_config():
+    mqtt_settings = Settings.MQTT(host="localhost")
+    number_info = NumberInfo(name="test")
+    settings = Settings(mqtt=mqtt_settings, entity=number_info)
+    # Define empty callback
+    number = Number(settings, lambda *_: None)
+    assert number is not None
+
+
+def test_set_value(number: Number):
+    number.set_value(42.0)
+
+
+def test_number_too_small(number: Number):
+    with pytest.raises(RuntimeError):
+        number.set_value(4.0)
+
+
+def test_number_too_large(number: Number):
+    with pytest.raises(RuntimeError):
+        number.set_value(91.0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

* Add the `Number` entity, which can control a single numeric value (just like how `Text` can control a single string)
  * Add docs for `Number` to the `README`
  * Add basic tests for `Number` (similar to the `Text` tests)
* Update some existing docs in `README`:
  * Add documentation for `Button`, which was undocumented before.
    * Document that you have to call `write_config()` to make buttons discoverable
  * Add example code to handle the typical payloads for a `Switch`
  * Update examples to make it clearer that, when you receive a command from HA, you also have to update the MQTT state on your entity (e.g. when you get an `"ON"` payload for a `Switch`, it's your job to call `on()`)

<!--- Describe your changes in detail -->

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [x] New feature
- [ ] Test updates
- [ ] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts added/updated in this PR are all marked executable.
- [x] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have confirmed that any links added or updated in my PR are valid.
