### PR TITLE
Fix 'f string' usage in debug log messages

### DIFF
--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -668,7 +668,7 @@ wrote_configuration: {self.wrote_configuration}
         """Create an MQTT client and setup some basic properties on it"""
         mqtt_settings = self._settings.mqtt
         logger.debug(
-            f"Creating mqtt client({mqtt_settings.client_name}) for "
+            f"Creating mqtt client ({mqtt_settings.client_name}) for "
             "{mqtt_settings.host}:{mqtt_settings.port}"
         )
         self.mqtt_client = mqtt.Client(mqtt_settings.client_name)

--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -669,7 +669,7 @@ wrote_configuration: {self.wrote_configuration}
         mqtt_settings = self._settings.mqtt
         logger.debug(
             f"Creating mqtt client ({mqtt_settings.client_name}) for "
-            "{mqtt_settings.host}:{mqtt_settings.port}"
+            f"{mqtt_settings.host}:{mqtt_settings.port}"
         )
         self.mqtt_client = mqtt.Client(mqtt_settings.client_name)
         if mqtt_settings.tls_key:
@@ -790,7 +790,7 @@ wrote_configuration: {self.wrote_configuration}
 
         logger.debug(
             f"Writing '{config_message}' to topic {self.config_topic} on "
-            "{self._settings.mqtt.host}:{self._settings.mqtt.port}"
+            f"{self._settings.mqtt.host}:{self._settings.mqtt.port}"
         )
         self.wrote_configuration = True
         self.config_message = config_message


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
Fix 'f string' usage in debug log messages,
it seems the mistake was introduce with this PR: https://github.com/unixorn/ha-mqtt-discoverable/pull/121/
<!--- Describe your changes in detail -->

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [x] Bug fix
- [ ] New feature
- [ ] Test updates
- [x] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
