### PR TITLE
Feature: Cover entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ Using MQTT discoverable devices lets us add new sensors and devices to HA withou
     - [Usage](#usage-3)
   - [Light](#light)
     - [Usage](#usage-4)
-  - [Text](#text)
+  - [Covers](#covers)
     - [Usage](#usage-5)
-  - [Number](#number)
+  - [Text](#text)
     - [Usage](#usage-6)
+  - [Number](#number)
+    - [Usage](#usage-7)
 - [Contributing](#contributing)
 - [Users of ha-mqtt-discoverable](#users-of-ha-mqtt-discoverable)
 - [Contributors](#contributors)
@@ -58,6 +60,8 @@ The following Home Assistant entities are currently implemented:
 - Sensor
 - Switch
 - Text
+- Light
+- Cover
 
 Each entity can associated to a device. See below for details.
 
@@ -309,6 +313,21 @@ my_light = Light(settings, my_callback, user_data)
 
 # Set the initial state of the light, which also makes it discoverable
 my_light.off()
+
+```
+
+### Covers
+
+A cover has four possible states `open`, `closed`, `opening`, `closing` and `stopped`. Most other entities use the states as command payload, but covers differentiate on this. The user HA user can either open, close or stop it in the covers current position.
+
+Covers do not currently support tilt.
+
+A `callback` function is needed in order to parse the commands sent from HA, as the following
+example shows:
+
+#### Usage
+
+```py
 
 ```
 

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -118,6 +118,40 @@ class LightInfo(EntityInfo):
     """The MQTT topic subscribed to receive state updates."""
 
 
+class CoverInfo(EntityInfo):
+    """Cover specific information"""
+
+    component: str = "cover"
+
+    optimistic: Optional[bool] = None
+    """Flag that defines if light works in optimistic mode.
+    Default: true if no state_topic defined, else false."""
+    payload_close: str = "CLOSE"
+    """Command payload to close the cover"""
+    payload_open: str = "OPEN"
+    """Command payload to open the cover"""
+    payload_stop: str = "STOP"
+    """Command payload to open the cover"""
+    position_closed: int = 0
+    """Number which represents the fully closed position"""
+    position_open: int = 100
+    """Number which represents the fully open position"""
+    state_open: str = "open"
+    """Payload that represents open state"""
+    state_opening: str = "opening"
+    """Payload that represents opening state"""
+    state_closed: str = "closed"
+    """Payload that represents closed state"""
+    state_closing: str = "closing"
+    """Payload that represents closing state"""
+    state_stopped: str = "stopped"
+    """Payload that represents stopped state"""
+    state_topic: Optional[str] = None
+    """The MQTT topic subscribed to receive state updates."""
+    retain: Optional[bool] = True
+    """If the published message should have the retain flag on or not"""
+
+
 class ButtonInfo(EntityInfo):
     """Button specific information"""
 
@@ -353,6 +387,45 @@ class Light(Subscriber[LightInfo]):
         json_state = json.dumps(state)
         self._state_helper(
             state=json_state, topic=self.state_topic, retain=self._entity.retain
+        )
+
+
+class Cover(Subscriber[CoverInfo]):
+    """Implements an MQTT cover:
+    https://www.home-assistant.io/integrations/cover.mqtt
+    """
+
+    def open(self) -> None:
+        """Set cover state to open"""
+        self._update_state(self._entity.state_open)
+
+    def closed(self) -> None:
+        """Set cover state to closed"""
+        self._update_state(self._entity.state_closed)
+
+    def closing(self) -> None:
+        """Set cover state to closing"""
+        self._update_state(self._entity.state_closing)
+
+    def opening(self) -> None:
+        """Set cover state to opening"""
+        self._update_state(self._entity.state_closed)
+
+    def stopped(self) -> None:
+        """Set cover state to stopped"""
+        self._update_state(self._entity.state_stopped)
+
+    def _update_state(self, state: str) -> None:
+        """
+        Update MQTT sensor state
+
+        Args:
+            state(str): What state to set the cover to
+        """
+        print("State: " + state)
+        logger.info(f"Setting {self._entity.name} to {state} using {self.state_topic}")
+        self._state_helper(
+            state=state, topic=self.state_topic, retain=self._entity.retain
         )
 
 

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -1,0 +1,46 @@
+import pytest
+from ha_mqtt_discoverable import Settings
+from ha_mqtt_discoverable.sensors import Cover, CoverInfo
+
+
+@pytest.fixture()
+def cover() -> Cover:
+    """Return a cover instance"""
+    mqtt_settings = Settings.MQTT(host="localhost")
+    sensor_info = CoverInfo(name="test")
+    settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
+    return Cover(settings, lambda *_: None)
+
+
+def test_required_config():
+    """Test to make sure a cover instance can be created"""
+    mqtt_settings = Settings.MQTT(host="localhost")
+    sensor_info = CoverInfo(name="test")
+    settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
+    sensor = Cover(settings, lambda *_: None)
+    assert sensor is not None
+
+
+def test_open(cover: Cover):
+    """Test to set a cover to open"""
+    cover.open()
+
+
+def test_closed(cover: Cover):
+    """Test to set a cover to closed"""
+    cover.closed()
+
+
+def test_closing(cover: Cover):
+    """Test to set a cover to closing"""
+    cover.closing()
+
+
+def test_opening(cover: Cover):
+    """Test to set a cover to opening"""
+    cover.opening()
+
+
+def test_stopped(cover: Cover):
+    """Test to set a cover to stopped"""
+    cover.stopped()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Basic support for cover entities

<!--- Describe your changes in detail -->
Covers reporting position or tilt position is not supported, yet. It can probably handled in a separate PR as it (might) require quite a bit of rework.
Tests are added as well as a readme entry.

**NOTE:** not tested  with actual hardware, as I do not own any.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [x] New feature
- [x] Test updates
- [ ] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts added/updated in this PR are all marked executable.
- [x] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have confirmed that any links added or updated in my PR are valid.
