### PR TITLE
Un-private Binary Sensor update_state

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ mysensor = BinarySensor(settings)
 mysensor.on()
 mysensor.off()
 
+# Or, change the state using a boolean
+mysensor.update_state(True)
+mysensor.update_state(False)
+
 # You can also set custom attributes on the sensor via a Python dict
 mysensor.set_attributes({"my attribute": "awesome"})
 

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -232,15 +232,15 @@ class BinarySensor(Discoverable[BinarySensorInfo]):
         """
         Set binary sensor to off
         """
-        self._update_state(state=False)
+        self.update_state(state=False)
 
     def on(self):
         """
         Set binary sensor to on
         """
-        self._update_state(state=True)
+        self.update_state(state=True)
 
-    def _update_state(self, state: bool) -> None:
+    def update_state(self, state: bool) -> None:
         """
         Update MQTT sensor state
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -46,3 +46,8 @@ def test_generate_config(sensor: BinarySensor):
 def test_update_state(sensor: BinarySensor):
     sensor.on()
     sensor.off()
+
+
+def test_boolean_state(sensor: BinarySensor):
+    sensor.update_state(True)
+    sensor.update_state(False)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
Change BinarySensor's `_update_state` to `update_state`
This would allow direct control of the Binary Sensor without extra if statements or breaking conventions.

<!--- Describe your changes in detail -->

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [x] New feature
- [x] Test updates
- [x] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts added/updated in this PR are all marked executable.
- [x] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have confirmed that any links added or updated in my PR are valid.
