### PR TITLE
 Add usage information for Sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ Using MQTT discoverable devices lets us add new sensors and devices to HA withou
     - [Usage](#usage-4)
   - [Number](#number)
     - [Usage](#usage-5)
-  - [Switch](#switch)
+  - [Sensor](#sensor)
     - [Usage](#usage-6)
-  - [Text](#text)
+  - [Switch](#switch)
     - [Usage](#usage-7)
+  - [Text](#text)
+    - [Usage](#usage-8)
 - [FAQ](#faq)
   - [I'm having problems on 32 bit ARM](#im-having-problems-on-32-bit-arm)
 - [Contributing](#contributing)
@@ -373,6 +375,36 @@ my_number = Number(settings, my_callback, user_data)
 # Set the initial number displayed in HA UI, publishing an MQTT message that gets picked up by HA
 my_number.set_value(42.0)
 
+```
+
+### Sensor
+
+#### Usage
+
+The following example creates a sensor and sets its state:
+
+```py
+from ha_mqtt_discoverable import Settings
+from ha_mqtt_discoverable.sensors import Sensor, SensorInfo
+
+
+# Configure the required parameters for the MQTT broker
+mqtt_settings = Settings.MQTT(host="localhost")
+
+# Information about the sensor
+sensor_info = SensorInfo(
+    name="MyTemperatureSensor",
+    device_class="temperature",
+    unit_of_measurement="°C",
+)
+
+settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
+
+# Instantiate the sensor
+mysensor = Sensor(settings)
+
+# Change the state of the sensor, publishing an MQTT message that gets picked up by HA
+mysensor.set_state(20.5)
 ```
 
 ### Switch

--- a/README.md
+++ b/README.md
@@ -19,19 +19,19 @@ Using MQTT discoverable devices lets us add new sensors and devices to HA withou
   - [Binary sensor](#binary-sensor)
     - [Usage](#usage)
   - [Button](#button)
-  - [Device](#device)
+  - [Covers](#covers)
     - [Usage](#usage-1)
+  - [Device](#device)
+    - [Usage](#usage-2)
   - [Device trigger](#device-trigger)
-      - [Usage](#usage-2)
-  - [Switch](#switch)
-    - [Usage](#usage-3)
+      - [Usage](#usage-3)
   - [Light](#light)
     - [Usage](#usage-4)
-  - [Covers](#covers)
-    - [Usage](#usage-5)
-  - [Text](#text)
-    - [Usage](#usage-6)
   - [Number](#number)
+    - [Usage](#usage-5)
+  - [Switch](#switch)
+    - [Usage](#usage-6)
+  - [Text](#text)
     - [Usage](#usage-7)
 - [FAQ](#faq)
   - [I'm having problems on 32 bit ARM](#im-having-problems-on-32-bit-arm)
@@ -136,6 +136,63 @@ my_button.write_config()
 
 ```
 
+### Covers
+
+A cover has five possible states `open`, `closed`, `opening`, `closing` and `stopped`. Most other entities use the states as command payload, but covers differentiate on this. The user HA user can either open, close or stop it in the covers current position.
+
+Covers do not currently support tilt.
+
+A `callback` function is needed in order to parse the commands sent from HA, as the following
+example shows:
+
+#### Usage
+
+```py
+from ha_mqtt_discoverable import Settings
+from ha_mqtt_discoverable.sensors import Cover, CoverInfo
+from paho.mqtt.client import Client, MQTTMessage
+
+# Configure the required parameters for the MQTT broker
+mqtt_settings = Settings.MQTT(host="localhost")
+
+# Information about the cover
+cover_info = CoverInfo(name="test")
+
+settings = Settings(mqtt=mqtt_settings, entity=cover_info)
+
+# To receive state commands from HA, define a callback function:
+def my_callback(client: Client, user_data, message: MQTTMessage):
+    payload = message.payload.decode()
+    if payload == "OPEN":
+    # let HA know that the cover is opening
+    my_cover.opening()
+    # call function to open cover
+        open_my_custom_cover()
+        # Let HA know that the cover was opened
+    my_cover.open()
+    if payload == "CLOSE":
+    # let HA know that the cover is closing
+    my_cover.closing()
+    # call function to close the cover
+        close_my_custom_cover()
+        # Let HA know that the cover was closed
+    my_cover.closed()
+    if payload == "STOP":
+    # call function to stop the cover
+        stop_my_custom_cover()
+        # Let HA know that the cover was stopped
+    my_cover.stopped()
+
+# Define an optional object to be passed back to the callback
+user_data = "Some custom data"
+
+# Instantiate the cover
+my_cover = Cover(settings, my_callback, user_data)
+
+# Set the initial state of the cover, which also makes it discoverable
+my_cover.closed()
+```
+
 ### Device
 From the [Home Assistant documentation](https://developers.home-assistant.io/docs/device_registry_index):
 > A device is a special entity in Home Assistant that is represented by one or more entities.
@@ -209,49 +266,6 @@ mytrigger = DeviceTrigger(settings)
 mytrigger.trigger("My custom payload")
 ```
 
-### Switch
-
-The switch is similar to a _binary sensor_, but in addition to publishing state changes toward HA it can also receive 'commands' from HA that request a state change.
-It is possible to act upon reception of this 'command', by defining a `callback` function, as the following example shows:
-
-#### Usage
-
-```py
-from ha_mqtt_discoverable import Settings
-from ha_mqtt_discoverable.sensors import Switch, SwitchInfo
-from paho.mqtt.client import Client, MQTTMessage
-
-# Configure the required parameters for the MQTT broker
-mqtt_settings = Settings.MQTT(host="localhost")
-
-# Information about the switch
-switch_info = SwitchInfo(name="test")
-
-settings = Settings(mqtt=mqtt_settings, entity=switch_info)
-
-# To receive state commands from HA, define a callback function:
-def my_callback(client: Client, user_data, message: MQTTMessage):
-    payload = message.payload.decode()
-    if payload == "ON":
-        turn_my_custom_thing_on()
-        # Let HA know that the switch was successfully activated
-	my_switch.on()
-    elif payload == "OFF":
-        turn_my_custom_thing_off()
-        # Let HA know that the switch was successfully deactivated
-	my_switch.off()
-
-# Define an optional object to be passed back to the callback
-user_data = "Some custom data"
-
-# Instantiate the switch
-my_switch = Switch(settings, my_callback, user_data)
-
-# Set the initial state of the switch, which also makes it discoverable
-my_switch.off()
-
-```
-
 ### Light
 
 The light is different from other current sensor as it needs its payload encoded/decoded as json.
@@ -322,61 +336,86 @@ my_light.off()
 
 ```
 
-### Covers
+### Number
 
-A cover has five possible states `open`, `closed`, `opening`, `closing` and `stopped`. Most other entities use the states as command payload, but covers differentiate on this. The user HA user can either open, close or stop it in the covers current position.
-
-Covers do not currently support tilt.
-
-A `callback` function is needed in order to parse the commands sent from HA, as the following
-example shows:
+The number entity is similar to the text entity, but for a numeric value instead of a string.
+It is possible to act upon receiving changes in HA by defining a `callback` function, as the following example shows:
 
 #### Usage
 
 ```py
 from ha_mqtt_discoverable import Settings
-from ha_mqtt_discoverable.sensors import Cover, CoverInfo
+from ha_mqtt_discoverable.sensors import Number, NumberInfo
 from paho.mqtt.client import Client, MQTTMessage
 
 # Configure the required parameters for the MQTT broker
 mqtt_settings = Settings.MQTT(host="localhost")
 
-# Information about the cover
-cover_info = CoverInfo(name="test")
+# Information about the `number` entity.
+number_info = NumberInfo(name="test", min=0, max=50, mode="slider", step=5)
 
-settings = Settings(mqtt=mqtt_settings, entity=cover_info)
+settings = Settings(mqtt=mqtt_settings, entity=number_info)
 
-# To receive state commands from HA, define a callback function:
+# To receive number updates from HA, define a callback function:
 def my_callback(client: Client, user_data, message: MQTTMessage):
-    payload = message.payload.decode()
-    if payload == "OPEN":
-	# let HA know that the cover is opening
-	my_cover.opening()
-	# call function to open cover
-        open_my_custom_cover()
-        # Let HA know that the cover was opened
-	my_cover.open()
-    if payload == "CLOSE":
-	# let HA know that the cover is closing
-	my_cover.closing()
-	# call function to close the cover
-        close_my_custom_cover()
-        # Let HA know that the cover was closed
-	my_cover.closed()
-    if payload == "STOP":
-	# call function to stop the cover
-        stop_my_custom_cover()
-        # Let HA know that the cover was stopped
-	my_cover.stopped()
+    number = int(message.payload.decode())
+    logging.info(f"Received {number} from HA")
+    do_some_custom_thing(number)
+    # Send an MQTT message to confirm to HA that the number was changed
+    my_number.set_value(number)
 
 # Define an optional object to be passed back to the callback
 user_data = "Some custom data"
 
-# Instantiate the cover
-my_cover = Cover(settings, my_callback, user_data)
+# Instantiate the number
+my_number = Number(settings, my_callback, user_data)
 
-# Set the initial state of the cover, which also makes it discoverable
-my_cover.closed()
+# Set the initial number displayed in HA UI, publishing an MQTT message that gets picked up by HA
+my_number.set_value(42.0)
+
+```
+
+### Switch
+
+The switch is similar to a _binary sensor_, but in addition to publishing state changes toward HA it can also receive 'commands' from HA that request a state change.
+It is possible to act upon reception of this 'command', by defining a `callback` function, as the following example shows:
+
+#### Usage
+
+```py
+from ha_mqtt_discoverable import Settings
+from ha_mqtt_discoverable.sensors import Switch, SwitchInfo
+from paho.mqtt.client import Client, MQTTMessage
+
+# Configure the required parameters for the MQTT broker
+mqtt_settings = Settings.MQTT(host="localhost")
+
+# Information about the switch
+switch_info = SwitchInfo(name="test")
+
+settings = Settings(mqtt=mqtt_settings, entity=switch_info)
+
+# To receive state commands from HA, define a callback function:
+def my_callback(client: Client, user_data, message: MQTTMessage):
+    payload = message.payload.decode()
+    if payload == "ON":
+        turn_my_custom_thing_on()
+        # Let HA know that the switch was successfully activated
+	my_switch.on()
+    elif payload == "OFF":
+        turn_my_custom_thing_off()
+        # Let HA know that the switch was successfully deactivated
+	my_switch.off()
+
+# Define an optional object to be passed back to the callback
+user_data = "Some custom data"
+
+# Instantiate the switch
+my_switch = Switch(settings, my_callback, user_data)
+
+# Set the initial state of the switch, which also makes it discoverable
+my_switch.off()
+
 ```
 
 ### Text
@@ -415,45 +454,6 @@ my_text = Text(settings, my_callback, user_data)
 
 # Set the initial text displayed in HA UI, publishing an MQTT message that gets picked up by HA
 my_text.set_text("Some awesome text")
-
-```
-
-### Number
-
-The number entity is similar to the text entity, but for a numeric value instead of a string.
-It is possible to act upon receiving changes in HA by defining a `callback` function, as the following example shows:
-
-#### Usage
-
-```py
-from ha_mqtt_discoverable import Settings
-from ha_mqtt_discoverable.sensors import Number, NumberInfo
-from paho.mqtt.client import Client, MQTTMessage
-
-# Configure the required parameters for the MQTT broker
-mqtt_settings = Settings.MQTT(host="localhost")
-
-# Information about the `number` entity.
-number_info = NumberInfo(name="test", min=0, max=50, mode="slider", step=5)
-
-settings = Settings(mqtt=mqtt_settings, entity=number_info)
-
-# To receive number updates from HA, define a callback function:
-def my_callback(client: Client, user_data, message: MQTTMessage):
-    number = int(message.payload.decode())
-    logging.info(f"Received {number} from HA")
-    do_some_custom_thing(number)
-    # Send an MQTT message to confirm to HA that the number was changed
-    my_number.set_value(number)
-
-# Define an optional object to be passed back to the callback
-user_data = "Some custom data"
-
-# Instantiate the number
-my_number = Number(settings, my_callback, user_data)
-
-# Set the initial number displayed in HA UI, publishing an MQTT message that gets picked up by HA
-my_number.set_value(42.0)
 
 ```
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -538,19 +538,18 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "69.5.1"
+version = "70.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-69.5.1-py3-none-any.whl", hash = "sha256:c636ac361bc47580504644275c9ad802c50415c7522212252c033bd15f301f32"},
-    {file = "setuptools-69.5.1.tar.gz", hash = "sha256:6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987"},
+    {file = "setuptools-70.0.0-py3-none-any.whl", hash = "sha256:54faa7f2e8d2d11bcd2c07bed282eef1046b5c080d1c32add737d7b5817b1ad4"},
+    {file = "setuptools-70.0.0.tar.gz", hash = "sha256:f211a66637b8fa059bb28183da127d4e86396c991a942b028c6650d4319c3fd0"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mypy (==1.9)", "packaging (>=23.2)", "pip (>=19.1)", "pytest (>=6,!=8.1.1)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mypy (==1.9)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.1)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "six"


### PR DESCRIPTION
# Description

This PR adds a usage section for `Sensor`s. It also alphabetically sorts the usage sections.

Note that this PR includes https://github.com/unixorn/ha-mqtt-discoverable/pull/228 in order to fix a `grype` check.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [ ] New feature
- [ ] Test updates
- [ ] Text cleanups/updates
- [x] Documentation update

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts added/updated in this PR are all marked executable.
- [x] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have confirmed that any links added or updated in my PR are valid.
