### PR TITLE
Added option to provide an existing mqtt client for the connection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Using MQTT discoverable devices lets us add new sensors and devices to HA withou
   - [Text](#text)
     - [Usage](#usage-8)
 - [FAQ](#faq)
+  - [Using an existing MQTT client](#using-an-existing-mqtt-client)
   - [I'm having problems on 32 bit ARM](#im-having-problems-on-32-bit-arm)
 - [Contributing](#contributing)
 - [Users of ha-mqtt-discoverable](#users-of-ha-mqtt-discoverable)
@@ -490,6 +491,26 @@ my_text.set_text("Some awesome text")
 ```
 
 ## FAQ
+
+### Using an existing MQTT client
+
+If you want to use an existing MQTT client for the connection, you can pass it to the `Settings` object:
+
+```py
+from ha_mqtt_discoverable import Settings
+from paho.mqtt.client import Client
+
+# Creating the MQTT client
+client = Client()
+# Doing other stuff with the client, like connecting to the broker
+# ...
+
+# Providing the client to the Settings object
+# In this case, no other MQTT settings are needed
+mqtt_settings = Settings.MQTT(client=client)
+
+# Continue with the rest of the code as usual
+```
 
 ### I'm having problems on 32 bit ARM
 


### PR DESCRIPTION
<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*

- [Description](#description)
- [License Acceptance](#license-acceptance)
- [Type of changes](#type-of-changes)
- [Checklist](#checklist)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

<!--- Provide a general summary of your changes in the Title above -->

# Description

Added the option to provide an existing mqtt client for the connection.
This can be used for the following use cases:
- Using the library in an application, where there is already an MQTT client created / managed by other parts of the program or other libraries. Especially when the credentials for a connection are externally managed and not easily available to pass to the `Settings.MQTT` option, this is useful.
- Offering compatibility with `paho-mqtt` version >2.0.0, where the client instantiation has changed. By providing an existing client, the library does not need to instantiate an own client and thus does not run into deprecation problems.

The existing mqtt client can be passed to th `Settings.MQTT` object as following:
```py
from ha_mqtt_discoverable import Settings
from paho.mqtt.client import Client

# Creating the MQTT client
client = Client()
# Doing other stuff with the client, like connecting to the broker
# ...

# Providing the client to the Settings object
# In this case, no other MQTT settings are needed
mqtt_settings = Settings.MQTT(client=client)

# Continue with the rest of the code as usual
``` 

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [x] New feature
- [ ] Test updates
- [ ] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] All new and existing tests pass.
- [x] I have confirmed that any links added or updated in my PR are valid.