### PR TITLE
Added Value_template and last_reset_value_template

### DIFF
--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -727,7 +727,7 @@ wrote_configuration: {self.wrote_configuration}
         self.mqtt_client.loop_start()
 
     def _state_helper(
-        self, state: Optional[Union[str, float, int]], topic: Optional[str] = None, retain=True
+        self, state: Optional[Union[str, float, int]], topic: Optional[str] = None, last_reset: Optional[str] = None, retain=True
     ) -> Optional[MQTTMessageInfo]:
         """
         Write a state to the given MQTT topic, returning the result of client.publish()
@@ -738,6 +738,8 @@ wrote_configuration: {self.wrote_configuration}
         if not topic:
             logger.debug(f"State topic unset, using default: {self.state_topic}")
             topic = self.state_topic
+        if last_reset:
+            state = {"state": state, "last_reset": last_reset}
         logger.debug(f"Writing '{state}' to {topic}")
 
         if self._settings.debug:

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -56,15 +56,17 @@ class SensorInfo(EntityInfo):
     If not None, the sensor is assumed to be numerical
     and will be displayed as a line-chart
     in the frontend instead of as discrete values."""
-    last_reset: Optional[str] = None
-    """The time when an accumulating sensor such as an electricity usage meter,
-    gas meter, water meter etc. was initialized.
-    If the time of initialization is unknown, set it to None.
-    Note that the datetime.datetime returned by the last_reset
-    property will be converted to an ISO 8601-formatted string
-    when the entity's state attributes are updated.
-    When changing last_reset, the state must be a valid number.
+    value_template: Optional[str] = None
     """
+    Defines a template to extract the value. 
+    If the template throws an error,
+    the current state will be used instead."""
+    last_reset_value_template: Optional[str] = None
+    """
+    Defines a template to extract the last_reset. 
+    When last_reset_value_template is set, the state_class option must be total. 
+    Available variables: entity_id. 
+    The entity_id can be used to reference the entity’s attributes."""
 
 
 class SwitchInfo(EntityInfo):
@@ -322,7 +324,7 @@ class BinarySensor(Discoverable[BinarySensorInfo]):
 
 
 class Sensor(Discoverable[SensorInfo]):
-    def set_state(self, state: str | int | float) -> None:
+    def set_state(self, state: str | int | float, last_reset: str = None) -> None:
         """
         Update the sensor state
 
@@ -330,7 +332,9 @@ class Sensor(Discoverable[SensorInfo]):
             state(str): What state to set the sensor to
         """
         logger.info(f"Setting {self._entity.name} to {state} using {self.state_topic}")
-        self._state_helper(str(state))
+        if last_reset:
+            logger.info("Setting last_reset to " + last_reset)
+        self._state_helper(str(state), last_reset=last_reset)
 
 
 # Inherit the on and off methods from the BinarySensor class, changing only the

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -58,14 +58,14 @@ class SensorInfo(EntityInfo):
     in the frontend instead of as discrete values."""
     value_template: Optional[str] = None
     """
-    Defines a template to extract the value. 
+    Defines a template to extract the value.
     If the template throws an error,
     the current state will be used instead."""
     last_reset_value_template: Optional[str] = None
     """
-    Defines a template to extract the last_reset. 
-    When last_reset_value_template is set, the state_class option must be total. 
-    Available variables: entity_id. 
+    Defines a template to extract the last_reset.
+    When last_reset_value_template is set, the state_class option must be total.
+    Available variables: entity_id.
     The entity_id can be used to reference the entity’s attributes."""
 
 


### PR DESCRIPTION
<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*

- [Description](#description)
- [License Acceptance](#license-acceptance)
- [Type of changes](#type-of-changes)
- [Checklist](#checklist)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

<!--- Provide a general summary of your changes in the Title above -->

# Description
added value_template and last_reset_value_template for Measurement.Total see Sensor Entity home assistant
https://www.home-assistant.io/integrations/sensor.mqtt/
<!--- Describe your changes in detail -->

# License Acceptance

- [ ] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [x] Bug fix
- [x] New feature
- [ ] Test updates
- [ ] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [ ] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [ ] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
