### PR TITLE
fixed set_state with last_update

### DIFF
--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -740,6 +740,7 @@ wrote_configuration: {self.wrote_configuration}
             topic = self.state_topic
         if last_reset:
             state = {"state": state, "last_reset": last_reset}
+            state = json.dumps(state)
         logger.debug(f"Writing '{state}' to {topic}")
 
         if self._settings.debug:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -47,19 +47,21 @@ def test_generate_config(sensor: Sensor):
 
 
 def test_update_state(sensor: Sensor):
-    with patch.object(sensor.mqtt_client, 'publish') as mock_publish:
+    with patch.object(sensor.mqtt_client, "publish") as mock_publish:
         sensor.set_state(1)
-        mock_publish.assert_called_with(sensor.state_topic, '1', retain=True)
+        mock_publish.assert_called_with(sensor.state_topic, "1", retain=True)
+
 
 def test_update_state_with_last_reset(sensor: Sensor):
     from datetime import datetime, timedelta, timezone
+
     now = datetime.now(timezone(timedelta(hours=1)))
     midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
 
-    with patch.object(sensor.mqtt_client, 'publish') as mock_publish:
+    with patch.object(sensor.mqtt_client, "publish") as mock_publish:
         sensor.set_state(1, midnight.isoformat())
         parameter = mock_publish.call_args.args[1]
         import json
-        parameter_json = json.loads(parameter)
-        assert parameter_json['last_reset'] == midnight.isoformat()
 
+        parameter_json = json.loads(parameter)
+        assert parameter_json["last_reset"] == midnight.isoformat()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -17,6 +17,7 @@ import pytest
 
 from ha_mqtt_discoverable import Settings
 from ha_mqtt_discoverable.sensors import Sensor, SensorInfo
+from unittest.mock import patch
 
 
 @pytest.fixture(params=["°C", "kWh"])
@@ -46,4 +47,21 @@ def test_generate_config(sensor: Sensor):
 
 
 def test_update_state(sensor: Sensor):
-    sensor.set_state(1)
+    with patch.object(sensor.mqtt_client, 'publish') as mock_publish:
+        sensor.set_state(1)
+        mock_publish.assert_called_with(sensor.state_topic, '1', retain=False)
+
+def test_update_state_with_last_reset(sensor: Sensor):
+    from datetime import datetime, timedelta, timezone
+    now = datetime.now(timezone(timedelta(hours=1)))
+    midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    with patch.object(sensor.mqtt_client, 'publish') as mock_publish:
+        sensor.set_state(1, midnight.isoformat())
+        mock_publish.assert_called_with(sensor.state_topic, '1', retain=False)
+        # Check the last_reset parameter
+        parameter1 = mock_publish.call_args.kwargs['payload']
+        print(f"parameter {parameter1}")
+        assert parameter1 == '1'
+        assert mock_publish.call_args.kwargs['last_reset'] == midnight.isoformat()
+

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -58,11 +58,8 @@ def test_update_state_with_last_reset(sensor: Sensor):
 
     with patch.object(sensor.mqtt_client, 'publish') as mock_publish:
         sensor.set_state(1, midnight.isoformat())
-        mock_publish.assert_called_with(sensor.state_topic, '1', retain=True)
-        # Check the last_reset parameter
-        parameter1 = mock_publish.call_args.kwargs['payload']
-        print(f"parameter {parameter1}")
+        parameter = mock_publish.call_args.args[1]
         import json
-        parameter1_json = json.loads(parameter1)
-        assert parameter1_json['last_reset'] == midnight.isoformat()
+        parameter_json = json.loads(parameter)
+        assert parameter_json['last_reset'] == midnight.isoformat()
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -49,7 +49,7 @@ def test_generate_config(sensor: Sensor):
 def test_update_state(sensor: Sensor):
     with patch.object(sensor.mqtt_client, 'publish') as mock_publish:
         sensor.set_state(1)
-        mock_publish.assert_called_with(sensor.state_topic, '1', retain=False)
+        mock_publish.assert_called_with(sensor.state_topic, '1', retain=True)
 
 def test_update_state_with_last_reset(sensor: Sensor):
     from datetime import datetime, timedelta, timezone
@@ -58,10 +58,11 @@ def test_update_state_with_last_reset(sensor: Sensor):
 
     with patch.object(sensor.mqtt_client, 'publish') as mock_publish:
         sensor.set_state(1, midnight.isoformat())
-        mock_publish.assert_called_with(sensor.state_topic, '1', retain=False)
+        mock_publish.assert_called_with(sensor.state_topic, '1', retain=True)
         # Check the last_reset parameter
         parameter1 = mock_publish.call_args.kwargs['payload']
         print(f"parameter {parameter1}")
-        assert parameter1 == '1'
-        assert mock_publish.call_args.kwargs['last_reset'] == midnight.isoformat()
+        import json
+        parameter1_json = json.loads(parameter1)
+        assert parameter1_json['last_reset'] == midnight.isoformat()
 


### PR DESCRIPTION
<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*

- [Description](#description)
- [License Acceptance](#license-acceptance)
- [Type of changes](#type-of-changes)
- [Checklist](#checklist)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [x] Bug fix
- [ ] New feature
- [x] Test updates
- [ ] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [ ] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
