### PR TITLE
MQTT Image integration fixes (fixes #305)

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,29 +321,20 @@ The following example creates an entity to an image url.
 ```py
 from ha_mqtt_discoverable import Settings
 from ha_mqtt_discoverable.sensors import Image, ImageInfo
-from paho.mqtt.client import Client, MQTTMessage
 
 # Configure the required parameters for the MQTT broker
 mqtt_settings = Settings.MQTT(host="localhost")
 
-# Information about the cover
-image_info = ImageInfo(name="test", url_topic ="http://camera.local/latest.jpg")
+# Information about the image
+image_info = ImageInfo(name="test", url_topic="topic_to_publish_url_to")
 
 settings = Settings(mqtt=mqtt_settings, entity=image_info)
 
-# To receive state commands from HA, define a callback function:
-def my_callback(client: Client, user_data, message: MQTTMessage):
-    payload = message.payload.decode()
-    perform_my_custom_action()
+# Instantiate the image
+my_image = Image(settings)
 
-# Define an optional object to be passed back to the callback
-user_data = "Some custom data"
-
-# Instantiate the cover
-my_image = Image(settings, my_callback, user_data)
-
-# Set the initial state of the cover, which also makes it discoverable
-my_image.set_url("http://camera.local/latest.jpg")	# not needed if already defined
+# Publish an image URL to url_topic
+my_image.set_url("http://camera.local/latest.jpg")
 ```
 
 ### Light

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -260,17 +260,17 @@ class CameraInfo(EntityInfo):
 
 class ImageInfo(EntityInfo):
     """
-    Information about the 'camera' entity.
+    Information about the 'image' entity.
     """
 
     component: str = "image"
-    """The component type is 'camera' for this entity."""
+    """The component type is 'image' for this entity."""
     availability_topic: Optional[str] = None
-    """The MQTT topic subscribed to publish the camera availability."""
+    """The MQTT topic subscribed to publish the image availability."""
     payload_available: Optional[str] = "online"
-    """Payload to publish to indicate the camera is online."""
+    """Payload to publish to indicate the image is online."""
     payload_not_available: Optional[str] = "offline"
-    """Payload to publish to indicate the camera is offline."""
+    """Payload to publish to indicate the image is offline."""
     url_topic: Optional[str] = None
     """
     The MQTT topic to subscribe to receive an image URL. A url_template option can extract the URL from the message.
@@ -589,9 +589,9 @@ class Camera(Subscriber[CameraInfo]):
         self.mqtt_client.publish(self._entity.availability_topic, payload, retain=self._entity.retain)
 
 
-class Image(Subscriber[ImageInfo]):
+class Image(Discoverable[ImageInfo]):
     """
-    Implements an MQTT camera for Home Assistant MQTT discovery:
+    Implements an MQTT image for Home Assistant MQTT discovery:
     https://www.home-assistant.io/integrations/image.mqtt/
     """
 
@@ -606,7 +606,7 @@ class Image(Subscriber[ImageInfo]):
             raise RuntimeError("Image URL cannot be empty")
 
         logger.info(f"Publishing image URL {image_url} to {self._entity.url_topic}")
-        self._state_helper(image_url)
+        self._state_helper(image_url, self._entity.url_topic)
 
 
 class Select(Subscriber[SelectInfo]):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,0 +1,54 @@
+#
+#    Copyright 2022-2024 Joe Block <jpb@unixorn.net>
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+from unittest.mock import patch
+
+import pytest
+from ha_mqtt_discoverable import Settings
+from ha_mqtt_discoverable.sensors import Image, ImageInfo
+
+
+@pytest.fixture()
+def image() -> Image:
+    mqtt_settings = Settings.MQTT(host="localhost")
+    image_info = ImageInfo(name="test", url_topic="topic_to_publish_url_to")
+    settings = Settings(mqtt=mqtt_settings, entity=image_info)
+    return Image(settings)
+
+
+def test_required_config():
+    """Test to make sure an image instance can be created"""
+    mqtt_settings = Settings.MQTT(host="localhost")
+    image_info = ImageInfo(name="test")
+    settings = Settings(mqtt=mqtt_settings, entity=image_info)
+    image = Image(settings)
+    assert image is not None
+
+
+def test_generate_config(image: Image):
+    config = image.generate_config()
+
+    assert config is not None
+    # If we have defined an url_topic, check that is part of the output config
+    if image._entity.url_topic:
+        assert config["url_topic"] == image._entity.url_topic
+
+
+def test_set_url(image: Image):
+    image_url = "http://camera.local/latest.jpg"
+
+    with patch.object(image.mqtt_client, "publish") as mock_publish:
+        image.set_url(image_url)
+        mock_publish.assert_called_with(image._entity.url_topic, image_url, retain=True)


### PR DESCRIPTION
<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*

- [Description](#description)

- fixes #305, the image url has to published to the *url_topic* note the *state* topic
- according to the official documentation this entity has no support for a *command* topic, so I changed *Image* to be a *Discoverable* only (see https://www.home-assistant.io/integrations/image.mqtt/)

- [License Acceptance](#license-acceptance)
- [Type of changes](#type-of-changes)
- [Checklist](#checklist)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [x] Bug fix
- [ ] New feature
- [x] Test updates
- [x] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
