### PR TITLE
MegaLinter: fix linter errors

### DIFF
--- a/.github/workflows/awesomebot.yml
+++ b/.github/workflows/awesomebot.yml
@@ -1,23 +1,22 @@
 ---
 name: Check links in README
 
-on:
+on: # yamllint disable-line rule:truthy
   push:
-    branches: [ '*' ]
+    branches: ["*"]
   pull_request:
-    branches: [ '*' ]
+    branches: ["*"]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        # Full git history is needed to get a proper list of changed files
-        # within `mega-linter`
-        fetch-depth: 0
-    - uses: docker://dkhamsing/awesome_bot:latest
-      with:
-        args: /github/workspace/README.md --allow-ssl --allow 500,501,502,503,504,509,521 --allow-dupe --allow-redirect --request-delay 1 --white-list https://github,https://img.shields.io,http://camera.local/latest.jpg
+      - uses: actions/checkout@v4
+        with:
+          # Full git history is needed to get a proper list of changed files
+          # within `mega-linter`
+          fetch-depth: 0
+      - uses: docker://dkhamsing/awesome_bot:latest
+        with:
+          args: /github/workspace/README.md --allow-ssl --allow 500,501,502,503,504,509,521 --allow-dupe --allow-redirect --request-delay 1 --white-list https://github,https://img.shields.io,http://camera.local/latest.jpg

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -1,9 +1,10 @@
+---
 # This workflow will build a Python wheel, a Docker image containing the CLI tool and publish both to PyPi and DockerHub
 
 name: Build and publish
 
 # Run only when pushing a Git version tag
-on:
+on: # yamllint disable-line rule:truthy
   push:
     tags:
       - "v*"

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -14,7 +14,7 @@ name: Lint Code Base
 #############################
 # Start the job on all push #
 #############################
-on:
+on: # yamllint disable-line rule:truthy
   push:
     branches-ignore: [main]
     # Remove the line above to run when pushing to main
@@ -51,21 +51,21 @@ jobs:
       - name: Lint Code Base
         uses: oxsecurity/megalinter/flavors/python@v8
         env:
-            ACTION_ACTIONLINT_DISABLE_ERRORS: true
-            DOCKERFILE_HADOLINT_DISABLE_ERRORS: true
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            PAT: ${{secrets.PAT}}
-            REPOSITORY_GITLEAKS_DISABLE_ERRORS: true
-            REPOSITORY_GITLEAKS_PR_COMMITS_SCAN: true
-            REPOSITORY_TRIVY_DISABLE_ERRORS: true
-            REPOSITORY_TRIVY_SBOM_DISABLE_ERRORS: true
-            VALIDATE_ALL_CODEBASE: false
-            YAML_YAMLLINT_DISABLE_ERRORS: true
+          ACTION_ACTIONLINT_DISABLE_ERRORS: true
+          DOCKERFILE_HADOLINT_DISABLE_ERRORS: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAT: ${{secrets.PAT}}
+          REPOSITORY_GITLEAKS_DISABLE_ERRORS: true
+          REPOSITORY_GITLEAKS_PR_COMMITS_SCAN: true
+          REPOSITORY_TRIVY_DISABLE_ERRORS: true
+          REPOSITORY_TRIVY_SBOM_DISABLE_ERRORS: true
+          VALIDATE_ALL_CODEBASE: false
+          YAML_YAMLLINT_DISABLE_ERRORS: true
 
       # Upload Mega-Linter artifacts.
-      # They will be available on Github action page "Artifacts" section
+      # They will be available on GitHub action page "Artifacts" section
       - name: Archive production artifacts
-        if: ${{ success() }} || ${{ failure() }}
+        if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v4
         env:
           PAT: ${{secrets.PAT}}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -4,12 +4,11 @@
 
 name: Python tests
 
-on:
+on: # yamllint disable-line rule:truthy
   push:
-    # Run against all branches
-    # branches: [ "main" ]
+    branches: ["*"]
   pull_request:
-    branches: ["main"]
+    branches: [main]
 
 permissions:
   contents: read
@@ -26,10 +25,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-          cache: 'poetry'
+          cache: "poetry"
       - name: Install dependencies
         run: poetry install
-        # Setup mosquitto broker for running tests
+      # Setup mosquitto broker for running tests
       - name: Setup mosquitto
         run: |
           docker run -d -v "${GITHUB_WORKSPACE}/tests/mosquitto.conf:/mosquitto/config/mosquitto.conf" -p 1883:1883 eclipse-mosquitto

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+http://camera.local/latest.jpg
+https://github/*


### PR DESCRIPTION
<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*

- [Description](#description)
- [License Acceptance](#license-acceptance)
- [Type of changes](#type-of-changes)
- [Checklist](#checklist)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

<!--- Provide a general summary of your changes in the Title above -->

# Description

- trivy and trivy-sbom are currently broken, as MegaLinter uses version 0.58.2 but support for Poetry 2.x was added in version 0.59.1 (see https://github.com/aquasecurity/trivy/issues/8322)

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [ ] New feature
- [ ] Test updates
- [ ] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
