### PR TITLE
SensorInfo: Add 'suggested_display_precision' (fixes #179)

### DIFF
--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Optional
+from typing import Annotated, Any, Optional
 
 from pydantic import Field
 
@@ -68,6 +68,10 @@ class SensorInfo(EntityInfo):
     When last_reset_value_template is set, the state_class option must be total.
     Available variables: entity_id.
     The entity_id can be used to reference the entity’s attributes."""
+    suggested_display_precision: None | Annotated[int, Field(ge=0)] = None
+    """
+    The number of decimals which should be used in the sensor’s state after rounding.
+    """
 
 
 class SwitchInfo(EntityInfo):


### PR DESCRIPTION
<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*

- [Description](#description)
- [License Acceptance](#license-acceptance)
- [Type of changes](#type-of-changes)
- [Checklist](#checklist)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

<!--- Provide a general summary of your changes in the Title above -->

# Description

Add support for https://www.home-assistant.io/integrations/sensor.mqtt/#suggested_display_precision
```
suggested_display_precision integer (Optional)

The number of decimals which should be used in the sensor’s state after rounding.
```


<!--- Describe your changes in detail -->

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [x] New feature
- [ ] Test updates
- [ ] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
