### PR TITLE
Fix externally created MQTT client usage (#fixes #331).

### DIFF
--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -21,6 +21,7 @@ from typing import Any, Generic, Optional, TypeVar, Union
 
 import paho.mqtt.client as mqtt
 from paho.mqtt.client import MQTTMessageInfo
+from paho.mqtt.enums import CallbackAPIVersion
 from pydantic import BaseModel, ConfigDict, model_validator
 
 # Read version from the package metadata
@@ -669,11 +670,14 @@ wrote_configuration: {self.wrote_configuration}
         # If the user has passed in an MQTT client, use it
         if self._settings.mqtt.client:
             self.mqtt_client = self._settings.mqtt.client
+            if on_connect:
+                logger.debug("Registering custom callback function")
+                self.mqtt_client.on_connect = on_connect
             return
 
         mqtt_settings = self._settings.mqtt
         logger.debug(f"Creating mqtt client ({mqtt_settings.client_name}) for {mqtt_settings.host}:{mqtt_settings.port}")
-        self.mqtt_client = mqtt.Client(callback_api_version=mqtt.CallbackAPIVersion.VERSION2, client_id=mqtt_settings.client_name)
+        self.mqtt_client = mqtt.Client(callback_api_version=CallbackAPIVersion.VERSION2, client_id=mqtt_settings.client_name)
         if mqtt_settings.tls_key:
             logger.info(f"Connecting to {mqtt_settings.host}:{mqtt_settings.port} with SSL and client certificate authentication")
             logger.debug(f"ca_certs={mqtt_settings.tls_ca_cert}")
@@ -714,9 +718,9 @@ wrote_configuration: {self.wrote_configuration}
             self.mqtt_client.will_set(self.availability_topic, "offline", retain=True)
 
     def _connect_client(self) -> None:
-        """Connect the client to the MQTT broker, start its onw internal loop in
+        """Connect the client to the MQTT broker, start its own internal loop in
         a separate thread"""
-        result = self.mqtt_client.connect(self._settings.mqtt.host, self._settings.mqtt.port or 1883)
+        result = self.mqtt_client.connect(self._settings.mqtt.host, self._settings.mqtt.port)
         # Check if we have established a connection
         if result != mqtt.MQTT_ERR_SUCCESS:
             raise RuntimeError("Error while connecting to MQTT broker")
@@ -870,7 +874,6 @@ class Subscriber(Discoverable[EntityType]):
 
         # Callback invoked when the MQTT connection is established
         def on_client_connected(client: mqtt.Client, *args):
-            # Publish this button in Home Assistant
             # Subscribe to the command topic
             result, _ = client.subscribe(self._command_topic, qos=1)
             if result is not mqtt.MQTT_ERR_SUCCESS:
@@ -885,8 +888,21 @@ class Subscriber(Discoverable[EntityType]):
         self.mqtt_client.user_data_set(user_data)
         self.mqtt_client.on_message = command_callback
 
-        # Manually connect the MQTT client
-        self._connect_client()
+        if self._settings.mqtt.client:
+            # externally created MQTT client is used
+            if self.mqtt_client.is_connected():
+                # MQTT client is already connect, therefor explicitly
+                # subscribe to the command topic
+                on_client_connected(self.mqtt_client)
+            else:
+                # externally created MQTT client is not connected yet
+                # the 'on_connect' callback named 'on_client_connected'
+                # will subscribe to the command topic
+                # when the externally created MQTT client connects
+                pass
+        else :
+            # Manually connect the MQTT client
+            self._connect_client()
 
     def generate_config(self) -> dict[str, Any]:
         """Override base config to add the command topic of this switch"""


### PR DESCRIPTION
<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*

- [Description](#description)
- [License Acceptance](#license-acceptance)
- [Type of changes](#type-of-changes)
- [Checklist](#checklist)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

<!--- Provide a general summary of your changes in the Title above -->

# Description


<!--- Describe your changes in detail -->

# License Acceptance

- [ ] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [ ] New feature
- [ ] Test updates
- [ ] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [ ] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [ ] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
