### PR TITLE
Image blob publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ img = Image.new(RGBA, (32, 32), (0,0,0,0))
 draw = ImageDraw.Draw(img)
 draw.circle((16,16), 10, fill="blue")
 image_buffer = BytesIO()
-image.save(image_buffer, format='PNG')
+img.save(image_buffer, format='PNG')
 my_image.set_blob(b64encode(image_buffer.get_value())
 
 ```

--- a/README.md
+++ b/README.md
@@ -311,7 +311,27 @@ my_image = Image(settings)
 
 # Publish an image URL to url_topic
 my_image.set_url("http://camera.local/latest.jpg")
+
+# Publish a file to a topic.
+from base64 import b64encode
+example_file = open("example.png", "r")
+example_blob = b64encode(example_file.read())
+my_image.set_blob(example_blob)
+
+# Create an image and publish directly.
+from base64 import b64encode
+from IO import BytesIO
+from PIL import Image, ImageDraw
+img = Image.new(RGBA, (32, 32), (0,0,0,0))
+draw = ImageDraw.Draw(img)
+draw.circle((16,16), 10, fill="blue")
+image_buffer = BytesIO()
+image.save(image_buffer, format='PNG')
+my_image.set_blob(b64encode(image_buffer.get_value())
+
 ```
+
+
 
 ### Light
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,6 @@ mqtt_settings = Settings.MQTT(host="localhost")
 
 # Information about the image
 image_info = ImageInfo(name="test", url_topic="topic_to_publish_url_to")
-
 settings = Settings(mqtt=mqtt_settings, entity=image_info)
 
 # Instantiate the image
@@ -316,6 +315,8 @@ my_image.set_url("http://camera.local/latest.jpg")
 from base64 import b64encode
 example_file = open("example.png", "r")
 example_blob = b64encode(example_file.read())
+image_info = ImageInfo(name="test", image_topic="topic_to_publish_image_to", image_encoding="raw")
+my_image = Image(settings)
 my_image.set_blob(example_blob)
 
 # Create an image and publish directly.
@@ -327,6 +328,8 @@ draw = ImageDraw.Draw(img)
 draw.circle((16,16), 10, fill="blue")
 image_buffer = BytesIO()
 img.save(image_buffer, format='PNG')
+image_info = ImageInfo(name="test", image_topic="topic_to_publish_image_to", image_encoding="b64")
+my_image = Image(settings)
 my_image.set_blob(b64encode(image_buffer.get_value())
 
 ```

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ mytrigger.trigger("My custom payload")
 
 ### Image
 
-The following example creates an entity to an image url.
+The following example creates an image entity to an image url.
 
 ```py
 from ha_mqtt_discoverable import Settings
@@ -302,7 +302,7 @@ from ha_mqtt_discoverable.sensors import Image, ImageInfo
 mqtt_settings = Settings.MQTT(host="localhost")
 
 # Information about the image
-image_info = ImageInfo(name="test", url_topic="topic_to_publish_url_to")
+image_info = ImageInfo(name="test", url_topic="topic_to_publish_image_url_to")
 settings = Settings(mqtt=mqtt_settings, entity=image_info)
 
 # Instantiate the image
@@ -310,31 +310,31 @@ my_image = Image(settings)
 
 # Publish an image URL to url_topic
 my_image.set_url("http://camera.local/latest.jpg")
-
-# Publish a file to a topic.
-from base64 import b64encode
-example_file = open("example.png", "r")
-example_blob = b64encode(example_file.read())
-image_info = ImageInfo(name="test", image_topic="topic_to_publish_image_to", image_encoding="raw")
-my_image = Image(settings)
-my_image.set_blob(example_blob)
-
-# Create an image and publish directly.
-from base64 import b64encode
-from IO import BytesIO
-from PIL import Image, ImageDraw
-img = Image.new(RGBA, (32, 32), (0,0,0,0))
-draw = ImageDraw.Draw(img)
-draw.circle((16,16), 10, fill="blue")
-image_buffer = BytesIO()
-img.save(image_buffer, format='PNG')
-image_info = ImageInfo(name="test", image_topic="topic_to_publish_image_to", image_encoding="b64")
-my_image = Image(settings)
-my_image.set_blob(b64encode(image_buffer.get_value())
-
 ```
 
+The following example creates an image entity and sets the base64 encoded payload.
 
+```py
+from ha_mqtt_discoverable import Settings
+from ha_mqtt_discoverable.sensors import Image, ImageInfo
+from base64 import b64encode
+
+# Configure the required parameters for the MQTT broker
+mqtt_settings = Settings.MQTT(host="localhost")
+
+# Information about the image
+image_info = ImageInfo(name="test", image_topic="topic_to_publish_image_payload_to",
+                       image_encoding="b64", content_type="image/png")
+settings = Settings(mqtt=mqtt_settings, entity=image_info)
+
+# Instantiate the image
+my_image = Image(settings)
+
+# Set the image payload
+with open("example.png", "rb") as example_file:
+    example_blob = b64encode(example_file.read())
+    my_image.set_payload(example_blob)
+```
 
 ### Light
 

--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -486,7 +486,7 @@ class DeviceInfo(BaseModel):
     """A link to the webpage that can manage the configuration of this device.
         Can be either an HTTP or HTTPS link."""
     suggested_area: str | None = None
-    """ The area to put the device in on creation, if it isn't already in one. """
+    """ The suggested name for the area where the device is located. """
     via_device: str | None = None
     """Identifier of a device that routes messages between this device and Home
         Assistant. Examples of such devices are hubs, or parent devices of a sub-device.

--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -485,6 +485,8 @@ class DeviceInfo(BaseModel):
     configuration_url: str | None = None
     """A link to the webpage that can manage the configuration of this device.
         Can be either an HTTP or HTTPS link."""
+    suggested_area: str | None = None
+    """ The area to put the device in on creation, if it isn't already in one. """
     via_device: str | None = None
     """Identifier of a device that routes messages between this device and Home
         Assistant. Examples of such devices are hubs, or parent devices of a sub-device.

--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -486,7 +486,7 @@ class DeviceInfo(BaseModel):
     """A link to the webpage that can manage the configuration of this device.
         Can be either an HTTP or HTTPS link."""
     suggested_area: str | None = None
-    """ The suggested name for the area where the device is located. """
+    """The suggested name for the area where the device is located."""
     via_device: str | None = None
     """Identifier of a device that routes messages between this device and Home
         Assistant. Examples of such devices are hubs, or parent devices of a sub-device.

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -624,7 +624,7 @@ class Image(Discoverable[ImageInfo]):
 
     def set_image(self, image_blob: str) -> None:
         """
-        Update the image state to the provided blob.
+        Update the image payload.
 
         Args:
             image_blob (str): An encoded blob of the image to be set as the image state. Must be Base64 encoded.

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -310,8 +310,7 @@ class ImageInfo(EntityInfo):
         # Don't set image_topic and url_topic at the same time.
         if self.image_topic and self.url_topic:
             raise ValueError(
-                "URL and Image payload sending cannot be used at the same time."
-                "Set only one of 'image_topic' or 'url_topic'"
+                "URL and Image payload sending cannot be used at the same time.Set only one of 'image_topic' or 'url_topic'"
             )
 
         # Don't set image_encoding and url_topic at the same time.

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -626,7 +626,7 @@ class Image(Discoverable[ImageInfo]):
         Update the image state to the provided blob.
 
         Args:
-            image_blob (str): An encoded blob of the image to be set as the image state.
+            image_blob (str): An encoded blob of the image to be set as the image state. Must be Base64 encoded.
         """
         if not image_blob:
             raise RuntimeError("Image blob cannot be empty")

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -282,11 +282,11 @@ class ImageInfo(EntityInfo):
     The content_type will be derived from the image when downloaded.
     Cannot be used with image_topic.
     """
-    image_topic: Optional[str] = None
+    image_topic: str | None = None
     """
     The MQTT topic to subscribe to receive a binary image. Cannot be used with url_topic.
     """
-    image_encoding: Optional[Literal['raw','b64']] = None
+    image_encoding: Literal["raw", "b64"] | None = None
     """
     Set the image encoding when sending images.
     """
@@ -300,7 +300,9 @@ class ImageInfo(EntityInfo):
         """
         # Don't allow URL and Image to be set at the same time.
         if self.image_topic is not None and self.url_topic is not None:
-            raise ValueError("URL and Image blob sending canot be used at the same time. Set only one of 'image_topic' and 'url_topic'")
+            raise ValueError(
+                "URL and Image blob sending canot be used at the same time. Set only one of 'image_topic' and 'url_topic'"
+            )
 
         # Don't set image_encoding and url_topic at the same time.
         if self.image_encoding is not None and self.url_topic is not None:

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -301,8 +301,8 @@ class ImageInfo(EntityInfo):
         # Don't allow URL and Image to be set at the same time.
         if self.image_topic is not None and self.url_topic is not None:
             raise ValueError(
-                "URL and Image blob sending canot be used at the same time. Set only one of 'image_topic' and 'url_topic'"
-            )
+                "URL and Image blob sending canot be used at the same time. Set only one of 'image_topic' and "
+                "'url_topic'")
 
         # Don't set image_encoding and url_topic at the same time.
         if self.image_encoding is not None and self.url_topic is not None:

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -301,8 +301,8 @@ class ImageInfo(EntityInfo):
         # Don't allow URL and Image to be set at the same time.
         if self.image_topic is not None and self.url_topic is not None:
             raise ValueError(
-                "URL and Image blob sending canot be used at the same time. Set only one of 'image_topic' and "
-                "'url_topic'")
+                "URL and Image blob sending canot be used at the same time. Set only one of 'image_topic' and 'url_topic'"
+            )
 
         # Don't set image_encoding and url_topic at the same time.
         if self.image_encoding is not None and self.url_topic is not None:

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -602,6 +602,7 @@ class Camera(Subscriber[CameraInfo]):
         logger.info(f"Setting camera availability to {payload} using {self._entity.availability_topic}")
         self.mqtt_client.publish(self._entity.availability_topic, payload, retain=self._entity.retain)
 
+
 class Image(Discoverable[ImageInfo]):
     """
     Implements an MQTT image for Home Assistant MQTT discovery:
@@ -633,6 +634,7 @@ class Image(Discoverable[ImageInfo]):
 
         logger.info(f"Publishing image blob to {self._entity.image_topic}")
         self._state_helper(image_blob, self._entity.image_topic)
+
 
 class Select(Subscriber[SelectInfo]):
     """

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -290,6 +290,10 @@ class ImageInfo(EntityInfo):
     """
     Set the image encoding when sending images.
     """
+    content_type: str | None = None
+    """
+    Content type to use when sending image blobs. If not specified HA assumes 'image/jpeg'
+    """
     retain: bool | None = None
     """If the published message should have the retain flag on or not."""
 
@@ -306,6 +310,10 @@ class ImageInfo(EntityInfo):
 
         # Don't set image_encoding and url_topic at the same time.
         if self.image_encoding is not None and self.url_topic is not None:
+            raise ValueError("Image encoding should not be set when using url_topic.")
+
+        # Don't set content_type and url_topic at the same time.
+        if self.content_type is not None and self.url_topic is not None:
             raise ValueError("Image encoding should not be set when using url_topic.")
 
         return self

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -280,6 +280,15 @@ class ImageInfo(EntityInfo):
     """
     The MQTT topic to subscribe to receive an image URL. A url_template option can extract the URL from the message.
     The content_type will be derived from the image when downloaded.
+    Cannot be used with image_topic.
+    """
+    image_topic: Optional[str] = None
+    """
+    The MQTT topic to subscribe to receive a binary image. Cannot be used with url_topic.
+    """
+    image_encoding: str = "b64"
+    """
+    Set the Image Encoding to Base64.
     """
     retain: bool | None = None
     """If the published message should have the retain flag on or not."""
@@ -593,7 +602,6 @@ class Camera(Subscriber[CameraInfo]):
         logger.info(f"Setting camera availability to {payload} using {self._entity.availability_topic}")
         self.mqtt_client.publish(self._entity.availability_topic, payload, retain=self._entity.retain)
 
-
 class Image(Discoverable[ImageInfo]):
     """
     Implements an MQTT image for Home Assistant MQTT discovery:
@@ -613,6 +621,18 @@ class Image(Discoverable[ImageInfo]):
         logger.info(f"Publishing image URL {image_url} to {self._entity.url_topic}")
         self._state_helper(image_url, self._entity.url_topic)
 
+    def set_image(self, image_blob: str) -> None:
+        """
+        Update the image state to the provided blob.
+
+        Args:
+            image_blob (str): An encoded blob of the image to be set as the image state.
+        """
+        if not image_blob:
+            raise RuntimeError("Image blob cannot be empty")
+
+        logger.info(f"Publishing image blob to {self._entity.image_topic}")
+        self._state_helper(image_blob, self._entity.image_topic)
 
 class Select(Subscriber[SelectInfo]):
     """

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -26,12 +26,9 @@ def image(request) -> Image:
     url_topic, image_topic, image_encoding, content_type = request.param
     mqtt_settings = Settings.MQTT(host="localhost")
     # image_info = ImageInfo(name="test", url_topic="topic_to_publish_url_to")
-    image_info = ImageInfo(name="test",
-                           url_topic=url_topic,
-                           image_topic=image_topic,
-                           image_encoding=image_encoding,
-                           content_type=content_type
-                           )
+    image_info = ImageInfo(
+        name="test", url_topic=url_topic, image_topic=image_topic, image_encoding=image_encoding, content_type=content_type
+    )
     settings = Settings(mqtt=mqtt_settings, entity=image_info)
     return Image(settings)
 
@@ -54,9 +51,11 @@ def test_url_and_encoding_raises_exception():
     with pytest.raises(ValueError):
         ImageInfo(name="test", url_topic="url_to_publish_to", image_encoding="b64")
 
+
 def test_url_and_content_type_raises_exception():
     with pytest.raises(ValueError):
         ImageInfo(name="test", url_topic="url_to_publish_to", image_encoding="b64")
+
 
 def test_invalid_encoding_raises_exception():
     with pytest.raises(ValueError):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -53,3 +53,17 @@ def test_set_url(image: Image):
     with patch.object(image.mqtt_client, "publish") as mock_publish:
         image.set_url(image_url)
         mock_publish.assert_called_with(image._entity.url_topic, image_url, retain=True)
+
+def test_set_blob(image: Image):
+    image_blob = ("base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAABhGlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV+/qGhFw"
+                  "Q4iDhmqkwVRUUepYhEslLZCqw4ml35Bk4YkxcVRcC04+LFYdXBx1tXBVRAEP0DcBSdFFynxf0mhRYwHx/14d+9x9w7wNipMMfzjg"
+                  "KKaeioeE7K5VSH4igD86MEM+kVmaIn0Ygau4+seHr7eRXmW+7k/R6+cNxjgEYjnmKabxBvE05umxnmfOMxKokx8Tjym0wWJH7kuO"
+                  "fzGuWizl2eG9UxqnjhMLBQ7WOpgVtIV4iniiKyolO/NOixz3uKsVGqsdU/+wlBeXUlzneYw4lhCAkkIkFBDGRWYiNKqkmIgRfsxF"
+                  "/+Q7U+SSyJXGYwcC6hCgWj7wf/gd7dGYXLCSQrFgMCLZX2MAMFdoFm3rO9jy2qeAL5n4Ept+6sNYPaT9HpbixwBfdvAxXVbk/aAy"
+                  "x1g8EkTddGWfDS9hQLwfkbflAMGboHuNae31j5OH4AMdbV8AxwcAqNFyl53eXdXZ2//nmn19wN6HHKqAAggmgAAAAlwSFlzAAAuI"
+                  "wAALiMBeKU/dgAAAAd0SU1FB+kFBAs3LBSX2/sAAAAZdEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIEdJTVBXgQ4XAAAADElEQVQI1"
+                  "2NgYGAAAAAEAAEnNCcKAAAAAElFTkSuQmCC")
+
+    with patch.object(image.mqtt_client, "publish") as mock_publish:
+        image.set_image(image_blob)
+        mock_publish.assert_called_with(image._entity.url_topic, image_blob, retain=True)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -27,8 +27,7 @@ def image(request) -> Image:
     url_topic, image_topic, image_encoding, content_type = request.param
     mqtt_settings = Settings.MQTT(host="localhost")
     image_info = ImageInfo(
-        name="test_image", url_topic=url_topic, image_topic=image_topic,
-        image_encoding=image_encoding, content_type=content_type
+        name="test_image", url_topic=url_topic, image_topic=image_topic, image_encoding=image_encoding, content_type=content_type
     )
     settings = Settings(mqtt=mqtt_settings, entity=image_info)
     return Image(settings)
@@ -45,14 +44,12 @@ def test_required_config():
 
 def test_url_topic_and_image_topic_set_raises_exception():
     with pytest.raises(ValueError):
-        ImageInfo(name="test", url_topic="url_to_publish_to",
-                  image_topic="image_to_publish_to")
+        ImageInfo(name="test", url_topic="url_to_publish_to", image_topic="image_to_publish_to")
 
 
 def test_url_topic_encoding_set_raises_exception():
     with pytest.raises(ValueError):
-        ImageInfo(name="test", url_topic="url_to_publish_to",
-                  image_encoding="b64")
+        ImageInfo(name="test", url_topic="url_to_publish_to", image_encoding="b64")
 
 
 def test_url_topic_content_type_set_raises_exception():
@@ -68,6 +65,7 @@ def test_image_topic_invalid_encoding_set_raises_exception():
 def test_image_topic_no_content_type_set_raises_exception():
     with pytest.raises(ValueError):
         ImageInfo(name="test", image_topic="image_to_publish_to")
+
 
 @pytest.mark.parametrize("image", [("topic_to_publish_to", None, None, None)], indirect=True)
 def test_generate_config_url(image: Image):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -30,6 +30,7 @@ def image(request) -> Image:
     settings = Settings(mqtt=mqtt_settings, entity=image_info)
     return Image(settings)
 
+
 def test_required_config():
     """Test to make sure an image instance can be created"""
     mqtt_settings = Settings.MQTT(host="localhost")
@@ -38,21 +39,25 @@ def test_required_config():
     image = Image(settings)
     assert image is not None
 
+
 def test_url_and_image_raises_exception():
     mqtt_settings = Settings.MQTT(host="localhost")
     with pytest.raises(ValueError) as excinfo:
         image_info = ImageInfo(name="test", url_topic="url_to_publish_to", image_topic="image_to_publish_to")
+
 
 def test_url_and_encoding_raises_exception():
     mqtt_settings = Settings.MQTT(host="localhost")
     with pytest.raises(ValueError) as excinfo:
         image_info = ImageInfo(name="test", url_topic="url_to_publish_to", image_encoding="b64")
 
+
 def test_invalid_encoding_raises_exception():
     mqtt_settings = Settings.MQTT(host="localhost")
     # settings = Settings(mqtt=mqtt_settings, entity=image_info)
     with pytest.raises(ValueError) as excinfo:
         image_info = ImageInfo(name="test", image_encoding="invalid_encoding", image_topic="image_to_publish_to")
+
 
 @pytest.mark.parametrize("image", [("topic_to_publish_to", None, None)], indirect=True)
 def test_generate_config_url(image: Image):
@@ -62,6 +67,7 @@ def test_generate_config_url(image: Image):
     if image._entity.url_topic:
         assert config["url_topic"] == image._entity.url_topic
 
+
 @pytest.mark.parametrize("image", [(None, "image_to_publish_to", "b64")], indirect=True)
 def test_generate_config_image(image: Image):
     config = image.generate_config()
@@ -70,6 +76,7 @@ def test_generate_config_image(image: Image):
     if image._entity.image_topic:
         assert config["image_topic"] == image._entity.image_topic
 
+
 @pytest.mark.parametrize("image", [("topic_to_publish_url_to", None, None)], indirect=True)
 def test_set_url(image: Image):
     image_url = "http://camera.local/latest.jpg"
@@ -77,6 +84,7 @@ def test_set_url(image: Image):
     with patch.object(image.mqtt_client, "publish") as mock_publish:
         image.set_url(image_url)
         mock_publish.assert_called_with(image._entity.url_topic, image_url, retain=True)
+
 
 @pytest.mark.parametrize("image", [(None, "image_to_publish_to", "b64")], indirect=True)
 def test_set_blob(image: Image):
@@ -88,10 +96,9 @@ def test_set_blob(image: Image):
         "/+Q7U+SSyJXGYwcC6hCgWj7wf/gd7dGYXLCSQrFgMCLZX2MAMFdoFm3rO9jy2qeAL5n4Ept+6sNYPaT9HpbixwBfdvAxXVbk/aAy"
         "x1g8EkTddGWfDS9hQLwfkbflAMGboHuNae31j5OH4AMdbV8AxwcAqNFyl53eXdXZ2//nmn19wN6HHKqAAggmgAAAAlwSFlzAAAuI"
         "wAALiMBeKU/dgAAAAd0SU1FB+kFBAs3LBSX2/sAAAAZdEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIEdJTVBXgQ4XAAAADElEQVQI1"
-        "2NgYGAAAAAEAAEnNCcKAAAAAElFTkSuQmCC")
+        "2NgYGAAAAAEAAEnNCcKAAAAAElFTkSuQmCC"
+    )
 
     with patch.object(image.mqtt_client, "publish") as mock_publish:
         image.set_image(image_blob)
         mock_publish.assert_called_with(image._entity.image_topic, image_blob, retain=True)
-
-

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -41,22 +41,18 @@ def test_required_config():
 
 
 def test_url_and_image_raises_exception():
-    mqtt_settings = Settings.MQTT(host="localhost")
-    with pytest.raises(ValueError) as excinfo:
-        image_info = ImageInfo(name="test", url_topic="url_to_publish_to", image_topic="image_to_publish_to")
+    with pytest.raises(ValueError):
+        ImageInfo(name="test", url_topic="url_to_publish_to", image_topic="image_to_publish_to")
 
 
 def test_url_and_encoding_raises_exception():
-    mqtt_settings = Settings.MQTT(host="localhost")
-    with pytest.raises(ValueError) as excinfo:
-        image_info = ImageInfo(name="test", url_topic="url_to_publish_to", image_encoding="b64")
+    with pytest.raises(ValueError):
+        ImageInfo(name="test", url_topic="url_to_publish_to", image_encoding="b64")
 
 
 def test_invalid_encoding_raises_exception():
-    mqtt_settings = Settings.MQTT(host="localhost")
-    # settings = Settings(mqtt=mqtt_settings, entity=image_info)
-    with pytest.raises(ValueError) as excinfo:
-        image_info = ImageInfo(name="test", image_encoding="invalid_encoding", image_topic="image_to_publish_to")
+    with pytest.raises(ValueError):
+        ImageInfo(name="test", image_encoding="invalid_encoding", image_topic="image_to_publish_to")
 
 
 @pytest.mark.parametrize("image", [("topic_to_publish_to", None, None)], indirect=True)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -22,12 +22,13 @@ from ha_mqtt_discoverable.sensors import Image, ImageInfo
 
 
 @pytest.fixture
-def image() -> Image:
+def image(request) -> Image:
+    url_topic, image_topic, image_encoding = request.param
     mqtt_settings = Settings.MQTT(host="localhost")
-    image_info = ImageInfo(name="test", url_topic="topic_to_publish_url_to")
+    # image_info = ImageInfo(name="test", url_topic="topic_to_publish_url_to")
+    image_info = ImageInfo(name="test", url_topic=url_topic, image_topic=image_topic, image_encoding=image_encoding)
     settings = Settings(mqtt=mqtt_settings, entity=image_info)
     return Image(settings)
-
 
 def test_required_config():
     """Test to make sure an image instance can be created"""
@@ -37,16 +38,39 @@ def test_required_config():
     image = Image(settings)
     assert image is not None
 
+def test_url_and_image_raises_exception():
+    mqtt_settings = Settings.MQTT(host="localhost")
+    with pytest.raises(ValueError) as excinfo:
+        image_info = ImageInfo(name="test", url_topic="url_to_publish_to", image_topic="image_to_publish_to")
 
-def test_generate_config(image: Image):
+def test_url_and_encoding_raises_exception():
+    mqtt_settings = Settings.MQTT(host="localhost")
+    with pytest.raises(ValueError) as excinfo:
+        image_info = ImageInfo(name="test", url_topic="url_to_publish_to", image_encoding="b64")
+
+def test_invalid_encoding_raises_exception():
+    mqtt_settings = Settings.MQTT(host="localhost")
+    # settings = Settings(mqtt=mqtt_settings, entity=image_info)
+    with pytest.raises(ValueError) as excinfo:
+        image_info = ImageInfo(name="test", image_encoding="invalid_encoding", image_topic="image_to_publish_to")
+
+@pytest.mark.parametrize("image", [("topic_to_publish_to", None, None)], indirect=True)
+def test_generate_config_url(image: Image):
     config = image.generate_config()
-
     assert config is not None
     # If we have defined an url_topic, check that is part of the output config
     if image._entity.url_topic:
         assert config["url_topic"] == image._entity.url_topic
 
+@pytest.mark.parametrize("image", [(None, "image_to_publish_to", "b64")], indirect=True)
+def test_generate_config_image(image: Image):
+    config = image.generate_config()
+    assert config is not None
+    # If we have defined an image_topic, check that is part of the output config
+    if image._entity.image_topic:
+        assert config["image_topic"] == image._entity.image_topic
 
+@pytest.mark.parametrize("image", [("topic_to_publish_url_to", None, None)], indirect=True)
 def test_set_url(image: Image):
     image_url = "http://camera.local/latest.jpg"
 
@@ -54,18 +78,20 @@ def test_set_url(image: Image):
         image.set_url(image_url)
         mock_publish.assert_called_with(image._entity.url_topic, image_url, retain=True)
 
+@pytest.mark.parametrize("image", [(None, "image_to_publish_to", "b64")], indirect=True)
+def test_set_blob(image: Image):
+    image_blob = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAABhGlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV+/qGhFw"
+        "Q4iDhmqkwVRUUepYhEslLZCqw4ml35Bk4YkxcVRcC04+LFYdXBx1tXBVRAEP0DcBSdFFynxf0mhRYwHx/14d+9x9w7wNipMMfzjg"
+        "KKaeioeE7K5VSH4igD86MEM+kVmaIn0Ygau4+seHr7eRXmW+7k/R6+cNxjgEYjnmKabxBvE05umxnmfOMxKokx8Tjym0wWJH7kuO"
+        "fzGuWizl2eG9UxqnjhMLBQ7WOpgVtIV4iniiKyolO/NOixz3uKsVGqsdU/+wlBeXUlzneYw4lhCAkkIkFBDGRWYiNKqkmIgRfsxF"
+        "/+Q7U+SSyJXGYwcC6hCgWj7wf/gd7dGYXLCSQrFgMCLZX2MAMFdoFm3rO9jy2qeAL5n4Ept+6sNYPaT9HpbixwBfdvAxXVbk/aAy"
+        "x1g8EkTddGWfDS9hQLwfkbflAMGboHuNae31j5OH4AMdbV8AxwcAqNFyl53eXdXZ2//nmn19wN6HHKqAAggmgAAAAlwSFlzAAAuI"
+        "wAALiMBeKU/dgAAAAd0SU1FB+kFBAs3LBSX2/sAAAAZdEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIEdJTVBXgQ4XAAAADElEQVQI1"
+        "2NgYGAAAAAEAAEnNCcKAAAAAElFTkSuQmCC")
 
-def test_image_blob(image: Image):
-    def test_set_blob(image: Image):
-        image_blob = (
-            "base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAABhGlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV+/qGhFw"
-            "Q4iDhmqkwVRUUepYhEslLZCqw4ml35Bk4YkxcVRcC04+LFYdXBx1tXBVRAEP0DcBSdFFynxf0mhRYwHx/14d+9x9w7wNipMMfzjg"
-            "KKaeioeE7K5VSH4igD86MEM+kVmaIn0Ygau4+seHr7eRXmW+7k/R6+cNxjgEYjnmKabxBvE05umxnmfOMxKokx8Tjym0wWJH7kuO"
-            "fzGuWizl2eG9UxqnjhMLBQ7WOpgVtIV4iniiKyolO/NOixz3uKsVGqsdU/+wlBeXUlzneYw4lhCAkkIkFBDGRWYiNKqkmIgRfsxF"
-            "/+Q7U+SSyJXGYwcC6hCgWj7wf/gd7dGYXLCSQrFgMCLZX2MAMFdoFm3rO9jy2qeAL5n4Ept+6sNYPaT9HpbixwBfdvAxXVbk/aAy"
-            "x1g8EkTddGWfDS9hQLwfkbflAMGboHuNae31j5OH4AMdbV8AxwcAqNFyl53eXdXZ2//nmn19wN6HHKqAAggmgAAAAlwSFlzAAAuI"
-            "wAALiMBeKU/dgAAAAd0SU1FB+kFBAs3LBSX2/sAAAAZdEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIEdJTVBXgQ4XAAAADElEQVQI1"
-            "2NgYGAAAAAEAAEnNCcKAAAAAElFTkSuQmCC"
-        )
-
+    with patch.object(image.mqtt_client, "publish") as mock_publish:
         image.set_image(image_blob)
+        mock_publish.assert_called_with(image._entity.image_topic, image_blob, retain=True)
+
+

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -54,3 +54,18 @@ def test_set_url(image: Image):
         image.set_url(image_url)
         mock_publish.assert_called_with(image._entity.url_topic, image_url, retain=True)
 
+
+def test_image_blob(image: Image):
+    def test_set_blob(image: Image):
+        image_blob = (
+            "base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAABhGlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV+/qGhFw"
+            "Q4iDhmqkwVRUUepYhEslLZCqw4ml35Bk4YkxcVRcC04+LFYdXBx1tXBVRAEP0DcBSdFFynxf0mhRYwHx/14d+9x9w7wNipMMfzjg"
+            "KKaeioeE7K5VSH4igD86MEM+kVmaIn0Ygau4+seHr7eRXmW+7k/R6+cNxjgEYjnmKabxBvE05umxnmfOMxKokx8Tjym0wWJH7kuO"
+            "fzGuWizl2eG9UxqnjhMLBQ7WOpgVtIV4iniiKyolO/NOixz3uKsVGqsdU/+wlBeXUlzneYw4lhCAkkIkFBDGRWYiNKqkmIgRfsxF"
+            "/+Q7U+SSyJXGYwcC6hCgWj7wf/gd7dGYXLCSQrFgMCLZX2MAMFdoFm3rO9jy2qeAL5n4Ept+6sNYPaT9HpbixwBfdvAxXVbk/aAy"
+            "x1g8EkTddGWfDS9hQLwfkbflAMGboHuNae31j5OH4AMdbV8AxwcAqNFyl53eXdXZ2//nmn19wN6HHKqAAggmgAAAAlwSFlzAAAuI"
+            "wAALiMBeKU/dgAAAAd0SU1FB+kFBAs3LBSX2/sAAAAZdEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIEdJTVBXgQ4XAAAADElEQVQI1"
+            "2NgYGAAAAAEAAEnNCcKAAAAAElFTkSuQmCC"
+        )
+
+        image.set_image(image_blob)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -54,16 +54,3 @@ def test_set_url(image: Image):
         image.set_url(image_url)
         mock_publish.assert_called_with(image._entity.url_topic, image_url, retain=True)
 
-def test_set_blob(image: Image):
-    image_blob = ("base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAABhGlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV+/qGhFw"
-                  "Q4iDhmqkwVRUUepYhEslLZCqw4ml35Bk4YkxcVRcC04+LFYdXBx1tXBVRAEP0DcBSdFFynxf0mhRYwHx/14d+9x9w7wNipMMfzjg"
-                  "KKaeioeE7K5VSH4igD86MEM+kVmaIn0Ygau4+seHr7eRXmW+7k/R6+cNxjgEYjnmKabxBvE05umxnmfOMxKokx8Tjym0wWJH7kuO"
-                  "fzGuWizl2eG9UxqnjhMLBQ7WOpgVtIV4iniiKyolO/NOixz3uKsVGqsdU/+wlBeXUlzneYw4lhCAkkIkFBDGRWYiNKqkmIgRfsxF"
-                  "/+Q7U+SSyJXGYwcC6hCgWj7wf/gd7dGYXLCSQrFgMCLZX2MAMFdoFm3rO9jy2qeAL5n4Ept+6sNYPaT9HpbixwBfdvAxXVbk/aAy"
-                  "x1g8EkTddGWfDS9hQLwfkbflAMGboHuNae31j5OH4AMdbV8AxwcAqNFyl53eXdXZ2//nmn19wN6HHKqAAggmgAAAAlwSFlzAAAuI"
-                  "wAALiMBeKU/dgAAAAd0SU1FB+kFBAs3LBSX2/sAAAAZdEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIEdJTVBXgQ4XAAAADElEQVQI1"
-                  "2NgYGAAAAAEAAEnNCcKAAAAAElFTkSuQmCC")
-
-    with patch.object(image.mqtt_client, "publish") as mock_publish:
-        image.set_image(image_blob)
-        mock_publish.assert_called_with(image._entity.url_topic, image_blob, retain=True)


### PR DESCRIPTION
<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*

- [Description](#description)
- [License Acceptance](#license-acceptance)
- [Type of changes](#type-of-changes)
- [Checklist](#checklist)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

<!--- Provide a general summary of your changes in the Title above -->

Added a 'set_blob' method to the Image class to allow publication of images directly from code. HA will take base64 encoded images directly via MQTT. I've found this helpful in situations where I don't have a web server to post images to. Added README examples for writing from a file or directly from PIL. Also added a test that passes, although am not 100% certain this is the correct test.

I also added 'suggested_area' an accepted field in DeviceInfo. This will set the Suggested Area for a device when an entity is discovered, if set.

<!--- Describe your changes in detail -->

# License Acceptance

- [X] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [X] New feature
- [ ] Test updates
- [ ] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [X] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [X] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
