### PR TITLE
Fixed Select behavior and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,9 +446,11 @@ user_data = "Some custom data"
 # Instantiate the selection
 my_selection = Select(settings, my_callback, user_data)
 
-# Set the initial state of the selection, which also makes it discoverable
-opt = ["option3", "option4", "option5"]
-my_selection.set_options(opt)
+# Publish the select's discoverability message to let HA automatically notice it
+my_selection.write_config()
+
+# Or set the initial state of the selection, which also makes it discoverable
+my_selection.set_option("option1")
 ```
 
 ### Sensor

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -617,8 +617,12 @@ class Select(Subscriber[SelectInfo]):
     Implements an MQTT select for Home Assistant MQTT discovery:
     https://www.home-assistant.io/integrations/select.mqtt/
     """
-
+    # Should be deprecated in the future. Kept for compatibility
     def set_options(self, opt: list) -> None:
+        self.set_option(opt)
+
+
+    def set_option(self, opt: str) -> None:
         """
         Update the selectable options.
 
@@ -626,7 +630,7 @@ class Select(Subscriber[SelectInfo]):
             opt (list): List of options that can be selected.
         """
         if not opt:
-            raise RuntimeError("Image URL cannot be empty")
+            raise RuntimeError("Option cannot be empty")
 
-        logger.info(f"Publishing options {opt} to {self._entity.options}")
+        logger.info(f"Setting {self._entity.name} to {opt} using {self.state_topic}")
         self._state_helper(opt)


### PR DESCRIPTION
<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*

- [Description](#description)
- [License Acceptance](#license-acceptance)
- [Type of changes](#type-of-changes)
- [Checklist](#checklist)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

<!--- Provide a general summary of your changes in the Title above -->

This PR fixes the behavior reported in [#355](https://github.com/unixorn/ha-mqtt-discoverable/issues/355) and also updates documentation to reflect changes. Additionally, it also changes the name of the function that updates the select value to a more friendly one while keeping compatibility. I think in the future, the original set_options function set_options() should be repurposed to actually do what was expected, which is update the available options during runtime.

<!--- Describe your changes in detail -->

# License Acceptance

- [X] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [X] Bug fix
- [ ] New feature
- [ ] Test updates
- [ ] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [X] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [X] All new and existing tests pass.
- [X] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [X] Scripts added/updated in this PR are all marked executable.
- [X] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [X] I have confirmed that any links added or updated in my PR are valid.
