### PR TITLE
MegaLinter: Disable GitHub Comment Reporter

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -30,12 +30,7 @@ jobs:
     name: Megalint Code Base
     # Set the agent to run on
     runs-on: ubuntu-latest
-    permissions:
-      # Give the default GITHUB_TOKEN write permission to commit and push, comment issues & post new PR
-      # Remove the ones you do not need
-      contents: write
-      issues: write
-      pull-requests: write
+
     ##################
     # Load all steps #
     ##################

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -3,7 +3,7 @@
 # See all available variables at https://megalinter.io/configuration/ and in linters documentation
 
 VALIDATE_ALL_CODEBASE: false
-
+GITHUB_COMMENT_REPORTER: false
 SPELL_MISSPELL_DISABLE_ERRORS: true
 
 DISABLE_LINTERS:


### PR DESCRIPTION


<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*

- [Description](#description)
- [License Acceptance](#license-acceptance)
- [Type of changes](#type-of-changes)
- [Checklist](#checklist)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

<!--- Provide a general summary of your changes in the Title above -->

# Description
Getting the MegaLinter GitHub Comment Reporter (https://github.com/oxsecurity/megalinter/blob/main/docs/reporters/GitHubCommentReporter.md) working was not successful

See:

- https://github.com/unixorn/ha-mqtt-discoverable/pull/361
- https://github.com/unixorn/ha-mqtt-discoverable/pull/362
 
<!--- Describe your changes in detail -->

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [ ] New feature
- [ ] Test updates
- [ ] Text cleanups/updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
