### PR TITLE
Remove 'user_data' from Subscriber class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,8 @@ settings = Settings(mqtt=mqtt_settings, entity=button_info)
 def my_callback(client: Client, user_data, message: MQTTMessage):
     perform_my_custom_action()
 
-# Define an optional object to be passed back to the callback
-user_data = "Some custom data"
-
 # Instantiate the button
-my_button = Button(settings, my_callback, user_data)
+my_button = Button(settings, my_callback)
 
 # Publish the button's discoverability message to let HA automatically notice it
 my_button.write_config()
@@ -154,11 +151,8 @@ def my_callback(client: Client, user_data, message: MQTTMessage):
     payload = message.payload.decode()
     perform_my_custom_action()
 
-# Define an optional object to be passed back to the callback
-user_data = "Some custom data"
-
 # Instantiate the cover
-my_camera = Camera(settings, my_callback, user_data)
+my_camera = Camera(settings, my_callback)
 
 # Set the initial state of the cover, which also makes it discoverable
 my_camera.set_topic("zanzito/shared_locations/my-device")  # not needed if already defined
@@ -209,11 +203,8 @@ def my_callback(client: Client, user_data, message: MQTTMessage):
         # Let HA know that the cover was stopped
         my_cover.stopped()
 
-# Define an optional object to be passed back to the callback
-user_data = "Some custom data"
-
 # Instantiate the cover
-my_cover = Cover(settings, my_callback, user_data)
+my_cover = Cover(settings, my_callback)
 
 # Set the initial state of the cover, which also makes it discoverable
 my_cover.closed()
@@ -393,11 +384,8 @@ def my_callback(client: Client, user_data, message: MQTTMessage):
     else:
         print("Unknown payload")
 
-# Define an optional object to be passed back to the callback
-user_data = "Some custom data"
-
 # Instantiate the light
-my_light = Light(settings, my_callback, user_data)
+my_light = Light(settings, my_callback)
 
 # Set the initial state of the light, which also makes it discoverable
 my_light.off()
@@ -430,11 +418,9 @@ def my_callback(client: Client, user_data, message: MQTTMessage):
     # Send an MQTT message to confirm to HA that the number was changed
     my_number.set_value(number)
 
-# Define an optional object to be passed back to the callback
-user_data = "Some custom data"
 
 # Instantiate the number
-my_number = Number(settings, my_callback, user_data)
+my_number = Number(settings, my_callback)
 
 # Set the initial number displayed in HA UI, publishing an MQTT message that gets picked up by HA
 my_number.set_value(42.0)
@@ -463,11 +449,8 @@ def my_callback(client: Client, user_data, message: MQTTMessage):
     payload = message.payload.decode()
     do_something()
 
-# Define an optional object to be passed back to the callback
-user_data = "Some custom data"
-
 # Instantiate the selection
-my_selection = Select(settings, my_callback, user_data)
+my_selection = Select(settings, my_callback)
 
 # Publish the select's discovery message to let HA automatically notice it
 my_selection.write_config()
@@ -534,11 +517,8 @@ def my_callback(client: Client, user_data, message: MQTTMessage):
         # Let HA know that the switch was successfully deactivated
         my_switch.off()
 
-# Define an optional object to be passed back to the callback
-user_data = "Some custom data"
-
 # Instantiate the switch
-my_switch = Switch(settings, my_callback, user_data)
+my_switch = Switch(settings, my_callback)
 
 # Set the initial state of the switch, which also makes it discoverable
 my_switch.off()
@@ -571,11 +551,8 @@ def my_callback(client: Client, user_data, message: MQTTMessage):
     # Send an MQTT message to confirm to HA that the text was changed
     my_text.set_text(text)
 
-# Define an optional object to be passed back to the callback
-user_data = "Some custom data"
-
 # Instantiate the text
-my_text = Text(settings, my_callback, user_data)
+my_text = Text(settings, my_callback)
 
 # Set the initial text displayed in HA UI, publishing an MQTT message that gets picked up by HA
 my_text.set_text("Some awesome text")

--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -858,7 +858,6 @@ class Subscriber(Discoverable[EntityType]):
         self,
         settings: Settings[EntityType],
         command_callback: Callable[[mqtt.Client, T, mqtt.MQTTMessage], Any],
-        user_data: T = None,
     ) -> None:
         """
         Entity that listens to commands from an MQTT topic.
@@ -883,8 +882,7 @@ class Subscriber(Discoverable[EntityType]):
         # Define the command topic to receive commands from HA, using `hmd` topic prefix
         self._command_topic = f"{self._settings.mqtt.state_prefix}/{self._entity_topic}/command"
 
-        # Register the user-supplied callback function with its user_data
-        self.mqtt_client.user_data_set(user_data)
+        # Register the user-supplied callback function
         self.mqtt_client.on_message = command_callback
 
         # Manually connect the MQTT client

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -58,17 +58,15 @@ def test_command_callback():
     # Flag that waits for the command to be received
     message_received = Event()
 
-    custom_user_data = "data"
-
     # Callback to receive the command message
     def custom_callback(client, user_data, message: MQTTMessage):
         payload = message.payload.decode()
         logging.info(f"Received {payload}")
         assert payload == "on"
-        assert user_data == custom_user_data
+        assert user_data is None
         message_received.set()
 
-    switch = Subscriber(settings, custom_callback, custom_user_data)
+    switch = Subscriber(settings, custom_callback)
     # Wait some seconds for the subscription to take effect
     time.sleep(2)
 


### PR DESCRIPTION
<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*

- [Description](#description)
- [Credit](#credit)
- [License Acceptance](#license-acceptance)
- [Type of changes](#type-of-changes)
- [Checklist](#checklist)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

<!-- Provide a general summary of your changes in the Title above -->

# Description
Preparation for supporting one MQTT client for all devices/entities:
**user_data** is used per MQTT client and therefor it does not make sense to set/overwrite it every time a *Subscriber* based entity is created.

<!-- Describe your changes in detail -->

# Credit
<!-- Releases are announced on Mastodon. In order for me to credit people properly, -->
<!-- if you have a mastodon account, please put it here to have it mentioned in the -->
<!-- release announcement. If there's another way you want to be credited, please   -->
<!-- add details here. -->

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of changes

<!-- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [x] Bug fix
- [ ] New feature
- [ ] Test updates
- [ ] Text cleanups/updates
- [ ] New release to PyPi

# Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
