### PR TITLE
Add information on thread spawning

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,7 +634,7 @@ Pydantic 2 has issues on 32-bit ARM. More details are on [ha-mqtt-discoverable/p
 
 ### I'm having problems running in systemd-Service
 
-Each entity creates its own thread for the MQTT-client-loop, which increases the task count. systemd may limit the tasks to a too low number for your needs (check with `systemctl status your.service`), which may lead to new entities failing to create a worker-thread. Try setting `TasksMax=` to an apropiate high number accommodating your entity count and other threads that may spawn.
+Each entity creates its own thread for the MQTT-client-loop, which increases the task count. systemd may limit the tasks to a too low number for your needs (check with `systemctl status your.service`), which may lead to new entities failing to create a worker-thread. Try setting `TasksMax=` to an appropriate high number accommodating your entity count and other threads that may spawn.
 
 Alternatively [use an existing MQTT client](#using-an-existing-mqtt-client) without each entity generating their own MQTT-client-loop.
 


### PR DESCRIPTION
<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*

- [Description](#description)
- [Credit](#credit)
- [License Acceptance](#license-acceptance)
- [Developer Certificate of Origin (DCO)](#developer-certificate-of-origin-dco)
- [Type of changes](#type-of-changes)
- [Checklist](#checklist)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

<!-- Provide a general summary of your changes in the Title above -->

Ran into issues when starting a script with >150 entities and systemd on a RPi Zero 2 W limiting the task count to 171, until I discovered that each entity creates its own thread and the limit was arbitrarily low. Added information for other users running into the same issue.

<!-- Describe your changes in detail -->

# Credit
@leinelab@chaos.social

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Developer Certificate of Origin (DCO)

The Developer Certificate of Origin (DCO) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project. Here is the full text of the DCO, reformatted for readability:

    By making a contribution to this project, I certify that:

    (a) The contribution was created in whole or in part by me and I have
    the right to submit it under the open source license indicated in the
    file; or

    (b) The contribution is based upon previous work that, to the best of
     my knowledge, is covered under an appropriate open source license and
     I have the right under that license to submit that work with
     modifications, whether created in whole or in part by me, under the
     same open source license (unless I am permitted to submit under a
     different license), as indicated in the file; or

    (c) The contribution was provided directly to me by some other person
    who certified (a), (b) or (c) and I have not modified it.

    (d) I understand and agree that this project and the contribution are
    public and that a record of the contribution (including all personal
    information I submit with it, including my sign-off) is maintained
    indefinitely and may be redistributed consistent with this project or
    the open source license(s) involved.

Contributors sign-off that they adhere to these requirements by adding a `Signed-off-by` line to commit messages.

```
This is my commit message

Signed-off-by: Random J Developer <random@developer.example.org>
```

Git even has a `-s` command line option to append this automatically to your commit message:

```sh
git commit -s -m 'This is my commit message'
```

# Type of changes

<!-- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [ ] New feature
- [ ] Test updates
- [ ] Text cleanups/updates
- [ ] New release to PyPi
- [x] Documentation update

# Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] I have signed off my commits per the DCO
- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts added/updated in this PR are all marked executable.
- [x] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have confirmed that any links added or updated in my PR are valid.
