### PR TITLE
Fix command topic subscriptions for externally created MQTT clients (fixes #468)

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,9 @@ my_text.set_text("Some awesome text")
 
 ## Availability Management
 
+> [!WARNING]
+> This features is not supported if using an [existing MQTT client](#using-an-existing-mqtt-client).
+
 If `manual_availability` is set to `True`:
 
 * `set_availability` has to be called to indicate if an entity is _available_ or _unavailable_
@@ -644,8 +647,12 @@ from paho.mqtt.client import Client
 
 # Creating the MQTT client
 client = Client()
-# Doing other stuff with the client, like connecting to the broker
+# Doing other stuff with the client
 # ...
+# Make sure the client is connected to the broker
+client.connect(host="localhost")
+# Also make sure the network communication is started
+client.loop_start()
 
 # Providing the client to the Settings object
 # In this case, no other MQTT settings are needed

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -14,32 +14,44 @@
 #    limitations under the License.
 #
 import logging
+import random
+import string
 import time
+from collections.abc import Callable
 from threading import Event
+from typing import Any, TypeVar
 
+import paho.mqtt.client as mqtt
 import pytest
 from paho.mqtt import publish
 from paho.mqtt.client import MQTTMessage
+from paho.mqtt.enums import CallbackAPIVersion
 
 from ha_mqtt_discoverable import EntityInfo, Settings, Subscriber
 
+T = TypeVar("T")  # Used in the callback function
+
 
 @pytest.fixture
-def subscriber() -> Subscriber[EntityInfo]:
-    mqtt_settings = Settings.MQTT(host="localhost")
-    sensor_info = EntityInfo(name="test", component="button")
-    settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
-    # Define an empty `command_callback`
-    return Subscriber(settings, lambda _, __, ___: None)
+def make_subscriber():
+    def _make_subscriber(
+        callback: Callable[[mqtt.Client, T, mqtt.MQTTMessage], Any] = lambda _, __, ___: None, mqtt_client: mqtt.Client = None
+    ):
+        mqtt_settings = Settings.MQTT(client=mqtt_client) if mqtt_client else Settings.MQTT(host="localhost")
+        sensor_info = EntityInfo(name="".join(random.choices(string.ascii_lowercase + string.digits, k=10)), component="button")
+        settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
+        return Subscriber(settings, callback)
+
+    return _make_subscriber
 
 
-def test_required_config():
-    mqtt_settings = Settings.MQTT(host="localhost")
-    sensor_info = EntityInfo(name="test", component="button")
-    settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
-    # Define empty callback
-    sensor = Subscriber(settings, lambda _, __, ___: None)
-    assert sensor is not None
+@pytest.fixture
+def subscriber(make_subscriber) -> Subscriber[EntityInfo]:
+    return make_subscriber()
+
+
+def test_required_config(subscriber: Subscriber):
+    assert subscriber is not None
 
 
 def test_generate_config(subscriber: Subscriber):
@@ -50,27 +62,44 @@ def test_generate_config(subscriber: Subscriber):
     assert config["command_topic"] == subscriber._command_topic
 
 
-def test_command_callback():
-    mqtt_settings = Settings.MQTT(host="localhost")
-    sensor_info = EntityInfo(name="test", component="switch")
-    settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
-
-    # Flag that waits for the command to be received
-    message_received = Event()
-
+def create_callback(event: Event, expected_payload: str) -> Callable:
     # Callback to receive the command message
     def custom_callback(_, user_data, message: MQTTMessage):
         payload = message.payload.decode()
         logging.info(f"Received {payload}")
-        assert payload == "on"
+        assert payload == expected_payload
         assert user_data is None
-        message_received.set()
+        event.set()
 
-    switch = Subscriber(settings, custom_callback)
-    # Wait some seconds for the subscription to take effect
-    time.sleep(2)
+    return custom_callback
+
+
+def create_external_mqtt_client() -> mqtt.Client:
+    mqtt_client = mqtt.Client(callback_api_version=CallbackAPIVersion.VERSION2)
+    mqtt_client.connect(host="localhost")
+    mqtt_client.loop_start()
+    return mqtt_client
+
+
+@pytest.mark.parametrize("mqtt_client", [None, create_external_mqtt_client()])
+def test_command_callbacks(make_subscriber, mqtt_client):
+    # Flag that waits for the command to be received
+    event1 = Event()
+    event2 = Event()
+    expected_payload1 = "on"
+    expected_payload2 = "off"
+    custom_callback1 = create_callback(event1, expected_payload1)
+    custom_callback2 = create_callback(event2, expected_payload2)
+    subscriber1 = make_subscriber(custom_callback1, mqtt_client)
+    subscriber2 = make_subscriber(custom_callback2, mqtt_client)
+    # Wait for the subscription to take effect
+    time.sleep(1)
+
+    assert subscriber1._command_topic != subscriber2._command_topic
 
     # Send a command to the command topic
-    publish.single(switch._command_topic, "on", hostname="localhost")
+    publish.single(subscriber1._command_topic, expected_payload1)
+    publish.single(subscriber2._command_topic, expected_payload2)
 
-    assert message_received.wait(2)
+    assert event1.wait(1)
+    assert event2.wait(1)


### PR DESCRIPTION
<!-- DOCTOC SKIP -->
# Description

<!-- Describe your changes in detail -->

## Credit
<!-- Releases are announced on Mastodon. In order for me to credit people properly, -->
<!-- if you have a mastodon account, please put it here to have it mentioned in the -->
<!-- release announcement. If there's another way you want to be credited, please   -->
<!-- add details here. -->

## License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

## Developer Certificate of Origin (DCO)

The Developer Certificate of Origin (DCO) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project. Here is the full text of the DCO, reformatted for readability:

```text
By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have
the right to submit it under the open source license indicated in the
file; or

(b) The contribution is based upon previous work that, to the best of
 my knowledge, is covered under an appropriate open source license and
 I have the right under that license to submit that work with
 modifications, whether created in whole or in part by me, under the
 same open source license (unless I am permitted to submit under a
 different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person
who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are
public and that a record of the contribution (including all personal
information I submit with it, including my sign-off) is maintained
indefinitely and may be redistributed consistent with this project or
the open source license(s) involved.
```

Contributors sign-off that they adhere to these requirements by adding a `Signed-off-by` line to commit messages.

```text
This is my commit message

Signed-off-by: Random J Developer <random@developer.example.org>
```

Git even has a `-s` command line option to append this automatically to your commit message:

```sh
git commit -s -m 'This is my commit message'
```

## Type of changes

<!-- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [x] Bug fix
- [ ] New feature
- [x] Test updates
- [ ] Text cleanups/updates
- [ ] New release to PyPi
- [x] Documentation update

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] I have signed off my commits per the DCO
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR *do not* have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
