### PR TITLE
Subscriber: handle external non-connected case gracefully

### DIFF
--- a/ha_mqtt_discoverable/__init__.py
+++ b/ha_mqtt_discoverable/__init__.py
@@ -392,7 +392,8 @@ wrote_configuration: {self.wrote_configuration}
 
 _all_subscribers: WeakSet["Subscriber"] = WeakSet()
 
-def _check_subscriptions(client:mqtt.Client, *_):
+
+def _check_subscriptions(client: mqtt.Client, *_):
     """Subscribe all Subscribers belonging to the given client.
 
     The function will be attached as client.on_connect for all MQTT clients used
@@ -405,6 +406,7 @@ def _check_subscriptions(client:mqtt.Client, *_):
     for subscriber in _all_subscribers.copy():
         if subscriber.mqtt_client is client:
             subscriber.on_reconnect()
+
 
 class Subscriber(Discoverable[EntityType]):
     """
@@ -442,17 +444,15 @@ class Subscriber(Discoverable[EntityType]):
                 self.mqtt_client.on_connect = _check_subscriptions
             if self.mqtt_client.on_connect != _check_subscriptions:
                 logger.warning(
-                    "Client's on_connect callback is already set." 
-                    f"Please subscribe commands yourself, using Subscriber.on_reconnect()."
+                    "Client's on_connect callback is already set."
+                    "Please subscribe commands yourself, using Subscriber.on_reconnect()."
                 )
             # Try to subscribe right away if the client is already connected
             try:
                 self.on_reconnect()
-            except RuntimeError as e:
+            except RuntimeError:
                 # Not connected yet, will subscribe in the on_connect callback
-                logger.debug(
-                    f"MQTT client is not connected yet, will subscribe to {self._command_topic} when connected."
-                )
+                logger.debug(f"MQTT client is not connected yet, will subscribe to {self._command_topic} when connected.")
                 pass
         else:
             # Manually connect the MQTT client

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -13,7 +13,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-from http import client
 import logging
 import random
 import string
@@ -110,13 +109,16 @@ def test_command_callbacks(make_subscriber, mqtt_client):
     assert event1.wait(1)
     assert event2.wait(1)
 
+
 def test_external_client_with_on_connect_not_replaced(make_subscriber):
     """If the client already brings an on_connect callback, it won't
     be touched when passed into a subscriber.
     """
     client = create_external_mqtt_client(False)
+
     def my_on_connect(client, userdata, flags, rc):
         pass
+
     client.on_connect = my_on_connect
     subscriber = make_subscriber(lambda *_: None, client)
     assert subscriber.mqtt_client.on_connect == my_on_connect


### PR DESCRIPTION
<!-- DOCTOC SKIP -->
# Description

Refers to Issue #509 - I tried my hand on it.

While working on this, I noticed that apparently ``on_client_connected`` was supposed to raise `RuntimeError` in my scenario, but didn't. I tested with a real server on another LAN host, not localhost - maybe that's why?

Anyway, here's my proposal. Have a look at it. I won't be mad if you reject it. ;-) The solution is as follows:

- Manage a (global) weakset of all subscribers.
- When any client connects, subscribe its associated subscribers. To this end, `_check_subscriptions` is set as `on_connect` callback; however,
- If mqtt_client.on_connect is not free to be set, don't replace but emit a warning.

Testing: Extend test_command_callbacks with the not-yet-connected case, and discard test_expect_exception_if_subscribing_the_command_topic_fails.

## Credit
<!-- Releases are announced on Mastodon. In order for me to credit people properly, -->
<!-- if you have a mastodon account, please put it here to have it mentioned in the -->
<!-- release announcement. If there's another way you want to be credited, please   -->
<!-- add details here. -->

## License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

## Developer Certificate of Origin (DCO)

The Developer Certificate of Origin (DCO) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project. Here is the full text of the DCO, reformatted for readability:

```text
By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have
the right to submit it under the open source license indicated in the
file; or

(b) The contribution is based upon previous work that, to the best of
 my knowledge, is covered under an appropriate open source license and
 I have the right under that license to submit that work with
 modifications, whether created in whole or in part by me, under the
 same open source license (unless I am permitted to submit under a
 different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person
who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are
public and that a record of the contribution (including all personal
information I submit with it, including my sign-off) is maintained
indefinitely and may be redistributed consistent with this project or
the open source license(s) involved.
```

Contributors sign-off that they adhere to these requirements by adding a `Signed-off-by` line to commit messages.

```text
This is my commit message

Signed-off-by: Random J Developer <random@developer.example.org>
```

Git even has a `-s` command line option to append this automatically to your commit message:

```sh
git commit -s -m 'This is my commit message'
```

## Type of changes

<!-- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [x] Bug fix
- [ ] New feature
- [x] Test updates
- [ ] Text cleanups/updates
- [ ] New release to PyPi
- [ ] Documentation update

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] I have signed off my commits per the DCO <-- *I'm not sure how to add the signature retroactively*
- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts added/updated in this PR are all marked executable.
- [x] Scripts added/updated in this PR *do not* have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
