### PR TITLE
Added Valve support

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,7 +715,7 @@ def my_callback(client: Client, user_data, message: MQTTMessage):
     move_my_custom_valve(payload)
     # Let HA know that the valve reached the desired position.
     # In HA the positions 0 or 100 automatically show as closed
-    # or open respectivly, other positions should return to
+    # or open respectively, other positions should return to
     # open, though this does not happen yet ([reported bug with pending fix](https://github.com/home-assistant/core/pull/165176).  
     my_valve.position(payload)
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ Using MQTT discoverable devices lets us add new sensors and devices to HA withou
 
 
 
-
-
 ## Installing
 
 ### Python

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Using MQTT discoverable devices lets us add new sensors and devices to HA withou
   - [Button](#button)
   - [Camera](#camera)
   - [Cover](#cover)
+  - [Valve](#valve)
   - [Device](#device)
   - [Device trigger](#device-trigger)
   - [Image](#image)
@@ -44,6 +45,7 @@ Using MQTT discoverable devices lets us add new sensors and devices to HA withou
 - [Contributors](#contributors)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 
 ## Installing
 
@@ -212,6 +214,106 @@ my_cover = Cover(settings, my_callback)
 
 # Set the initial state of the cover, which also makes it discoverable
 my_cover.closed()
+```
+
+### Valve
+
+A valve has five possible states `open`, `closed`, `opening`, `closing` and `stopped`, a position (0-100) or a combination in json format `'{"state": "opening|colsing", "position": 42}'`.
+
+The command payload can be either `OPEN`, `CLOSE` or `STOP` or a position (0-100).
+
+The HA user can either open, close and stop it in the valves current position (`reports_position = False`) or control the valves position via a slider (`reports_position = True`). The states `open`, `closed` and the commands `OPEN`, `CLOSE` are only allowed with `reports_position = False`. Positions are only effective with `reports_position = True`.
+
+A `callback` function is needed in order to parse the commands sent from HA, as the following example shows:
+
+```py
+from ha_mqtt_discoverable import Settings
+from ha_mqtt_discoverable.sensors import Valve, ValveInfo
+from paho.mqtt.client import Client, MQTTMessage
+
+
+# Configure the required parameters for the MQTT broker
+mqtt_settings = Settings.MQTT(host="localhost")
+
+### stated controled valve ###
+# Information about the valve
+valve_info = ValveInfo(name="test")
+
+settings = Settings(mqtt=mqtt_settings, entity=valve_info)
+
+# To receive state commands from HA, define a callback function:
+def my_callback(client: Client, user_data, message: MQTTMessage):
+    payload = message.payload.decode()
+    if payload == my_valve._entity.payload_open:
+        # let HA know that the valve is opening
+        my_valve.opening()
+        # call function to open valve
+        open_my_custom_valve()
+        # Let HA know that the valve was opened
+        my_valve.open()
+    elif payload == my_valve._entity.payload_close:
+        # let HA know that the valve is closing
+        my_valve.closing()
+        # call function to close valve
+        close_my_custom_valve()
+        # Let HA know that the valve was closed
+        my_valve.closed()
+    # if payload_stop is defined, stop a valve in motion
+    elif payload == my_valve._entity.payload_stop:
+        # call function to stop the valve.  
+        stop_my_custom_valve()
+        # There is no my_valve.stoped(). This means
+        # the function should call my_valve.open() or
+        # my_valve.closed() depending on the valve
+        # state. Otherwise the state opening|closing
+        # remains active.
+
+# Instantiate the valve
+my_valve = Valve(settings, my_callback)
+
+# Set the initial state of the valve, which also makes it discoverable
+my_valve.closed()
+
+### position controled valve ###
+# Information about the valve
+valve_info = ValveInfo(name="test-position", reports_position=True)
+
+settings = Settings(mqtt=mqtt_settings, entity=valve_info)
+
+current_position = 0
+
+# To receive state commands from HA, define a callback function:
+def my_callback(client: Client, user_data, message: MQTTMessage):
+    nonlocal current_position
+    payload = message.payload.decode()
+    # convert the payload of type str to int
+    try:
+        payload = int(payload)
+    except:
+        logger.error("Wrong payload")
+        return
+
+    if payload < current_position:
+        # let HA know that the valve is closing
+        my_position_valve.position(current_position, my_valve._entity.state_closing)
+    else:
+        # let HA know that the valve is closing
+        my_position_valve.position(current_position, my_valve._entity.state_opening)
+    # call function to move the valve to the desired position
+    move_my_custom_valve(payload)
+    # Let HA know that the valve reached the desired position.
+    # In HA the positions 0 or 100 automatically show as closed
+    # or open respectivly, other positions should return to
+    # open, though this does not happen yet (reported bug).  
+    my_position_valve.position(payload)
+    current_position = payload
+
+# Instantiate the valve
+my_position_valve = Valve(settings, my_callback)
+
+# Set the initial state of the valve, which also makes it discoverable
+my_position_valve.position(0)
+
 ```
 
 ### Device

--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ my_valve = Valve(settings, my_callback)
 my_valve.closed()
 ```
 #### Position command valve
-This mode is active when `reports_position = True`. The mode is different from other sensors as it can send a payload encoded/decoded as JSON, like the light device can.
+This mode is active when `reports_position = True`. The mode is different from other sensors as it can send a payload encoded/decoded as JSON, like the light entity can.
 
 The valve can report two possible states `opening` and `closing`, a position (0-100) or a combination in JSON format, for example: `'{"state": "opening", "position": 42}'`. The command payload can be either `STOP` or a position (0-100).
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Using MQTT discoverable devices lets us add new sensors and devices to HA withou
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 
+
 ## Installing
 
 ### Python
@@ -230,7 +231,6 @@ A `callback` function is needed in order to parse the commands sent from HA, as 
 from ha_mqtt_discoverable import Settings
 from ha_mqtt_discoverable.sensors import Valve, ValveInfo
 from paho.mqtt.client import Client, MQTTMessage
-
 
 # Configure the required parameters for the MQTT broker
 mqtt_settings = Settings.MQTT(host="localhost")

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ Using MQTT discoverable devices lets us add new sensors and devices to HA withou
   - [Button](#button)
   - [Camera](#camera)
   - [Cover](#cover)
-  - [Valve](#valve)
-  - [Device](#device)
   - [Device trigger](#device-trigger)
   - [Image](#image)
   - [Light](#light)
@@ -33,6 +31,9 @@ Using MQTT discoverable devices lets us add new sensors and devices to HA withou
   - [Sensor](#sensor)
   - [Switch](#switch)
   - [Text](#text)
+  - [Valve](#valve)
+    - [Action command valve](#action-command-valve)
+    - [Position command valve](#position-command-valve)
 - [Availability Management](#availability-management)
 - [Limited state changes publications](#limited-state-changes-publications)
 - [FAQ](#faq)
@@ -45,6 +46,7 @@ Using MQTT discoverable devices lets us add new sensors and devices to HA withou
 - [Contributors](#contributors)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 
 
 
@@ -215,106 +217,6 @@ my_cover = Cover(settings, my_callback)
 
 # Set the initial state of the cover, which also makes it discoverable
 my_cover.closed()
-```
-
-### Valve
-
-A valve has five possible states `open`, `closed`, `opening`, `closing` and `stopped`, a position (0-100) or a combination in json format `'{"state": "opening|colsing", "position": 42}'`.
-
-The command payload can be either `OPEN`, `CLOSE` or `STOP` or a position (0-100).
-
-The HA user can either open, close and stop it in the valves current position (`reports_position = False`) or control the valves position via a slider (`reports_position = True`). The states `open`, `closed` and the commands `OPEN`, `CLOSE` are only allowed with `reports_position = False`. Positions are only effective with `reports_position = True`.
-
-A `callback` function is needed in order to parse the commands sent from HA, as the following example shows:
-
-```py
-from ha_mqtt_discoverable import Settings
-from ha_mqtt_discoverable.sensors import Valve, ValveInfo
-from paho.mqtt.client import Client, MQTTMessage
-
-# Configure the required parameters for the MQTT broker
-mqtt_settings = Settings.MQTT(host="localhost")
-
-### stated controled valve ###
-# Information about the valve
-valve_info = ValveInfo(name="test")
-
-settings = Settings(mqtt=mqtt_settings, entity=valve_info)
-
-# To receive state commands from HA, define a callback function:
-def my_callback(client: Client, user_data, message: MQTTMessage):
-    payload = message.payload.decode()
-    if payload == my_valve._entity.payload_open:
-        # let HA know that the valve is opening
-        my_valve.opening()
-        # call function to open valve
-        open_my_custom_valve()
-        # Let HA know that the valve was opened
-        my_valve.open()
-    elif payload == my_valve._entity.payload_close:
-        # let HA know that the valve is closing
-        my_valve.closing()
-        # call function to close valve
-        close_my_custom_valve()
-        # Let HA know that the valve was closed
-        my_valve.closed()
-    # if payload_stop is defined, stop a valve in motion
-    elif payload == my_valve._entity.payload_stop:
-        # call function to stop the valve.  
-        stop_my_custom_valve()
-        # There is no my_valve.stoped(). This means
-        # the function should call my_valve.open() or
-        # my_valve.closed() depending on the valve
-        # state. Otherwise the state opening|closing
-        # remains active.
-
-# Instantiate the valve
-my_valve = Valve(settings, my_callback)
-
-# Set the initial state of the valve, which also makes it discoverable
-my_valve.closed()
-
-### position controled valve ###
-# Information about the valve
-valve_info = ValveInfo(name="test-position", reports_position=True)
-
-settings = Settings(mqtt=mqtt_settings, entity=valve_info)
-
-current_position = 0
-
-# To receive state commands from HA, define a callback function:
-def my_callback(client: Client, user_data, message: MQTTMessage):
-    nonlocal current_position
-    payload = message.payload.decode()
-    # convert the payload of type str to int
-    try:
-        payload = int(payload)
-    except:
-        logger.error("Wrong payload")
-        return
-
-    if payload < current_position:
-        # let HA know that the valve is closing
-        my_position_valve.position(current_position, my_valve._entity.state_closing)
-    else:
-        # let HA know that the valve is closing
-        my_position_valve.position(current_position, my_valve._entity.state_opening)
-    # call function to move the valve to the desired position
-    move_my_custom_valve(payload)
-    # Let HA know that the valve reached the desired position.
-    # In HA the positions 0 or 100 automatically show as closed
-    # or open respectivly, other positions should return to
-    # open, though this does not happen yet (reported bug).  
-    my_position_valve.position(payload)
-    current_position = payload
-
-# Instantiate the valve
-my_position_valve = Valve(settings, my_callback)
-
-# Set the initial state of the valve, which also makes it discoverable
-my_position_valve.position(0)
-
-```
 
 ### Device
 
@@ -705,6 +607,121 @@ my_text = Text(settings, my_callback)
 
 # Set the initial text displayed in HA UI, publishing an MQTT message that gets picked up by HA
 my_text.set_text("Some awesome text")
+```
+
+### Valve
+
+The valve has two control modes: action command and position command. The first, most simple way is explained first.
+
+#### Action command valve
+This mode is active when `reports_position = False`. A valve in this mode can report five possible states `open`, `closed`, `opening`, `closing` and `stopped`. The command payload can be either `OPEN`, `CLOSE` or `STOP`, where `STOP` is optional.
+
+A `callback` function is needed in order to parse the commands sent from HA, as the example shows:
+
+```py
+from ha_mqtt_discoverable import Settings
+from ha_mqtt_discoverable.sensors import Valve, ValveInfo
+from paho.mqtt.client import Client, MQTTMessage
+
+# Configure the required parameters for the MQTT broker
+mqtt_settings = Settings.MQTT(host="localhost")
+
+# Information about the valve
+valve_info = ValveInfo(name="test")
+
+settings = Settings(mqtt=mqtt_settings, entity=valve_info)
+
+# To receive state commands from HA, define a callback function:
+def my_callback(client: Client, user_data, message: MQTTMessage):
+    payload = message.payload.decode()
+    if payload == my_valve._entity.payload_open:
+        # let HA know that the valve is opening
+        my_valve.opening()
+        # call function to open valve
+        open_my_custom_valve()
+        # Let HA know that the valve was opened
+        my_valve.open()
+    elif payload == my_valve._entity.payload_close:
+        # let HA know that the valve is closing
+        my_valve.closing()
+        # call function to close valve
+        close_my_custom_valve()
+        # Let HA know that the valve was closed
+        my_valve.closed()
+    # if payload_stop is defined, stop a valve in motion
+    elif payload == my_valve._entity.payload_stop:
+        # call function to stop the valve.  
+        stop_my_custom_valve()
+        # There is no my_valve.stopped(). This means
+        # the function should call my_valve.open() or
+        # my_valve.closed() depending on the valve
+        # state. Otherwise the former state remains
+        # active, this could thus be opening or
+        # closing.
+
+# Instantiate the valve
+my_valve = Valve(settings, my_callback)
+
+# Set the initial state of the valve, which also makes it discoverable
+my_valve.closed()
+```
+#### Position command valve
+This mode is active when `reports_position = True`. The mode is different from other sensors as it can send a payload encoded/decoded as JSON, like the light device can. The valve can report two possible states `opening` and `closing`, a position (0-100) or a combination in JSON format, for example: `'{"state": "opening", "position": 42}'`. The command payload can be either `STOP` or a position (0-100). Note that in this mode payload_open, payload_close, state_open and state_closed must be set to None.
+
+A `callback` function is needed in order to parse the commands sent from HA, as the following example shows:
+
+```py
+from ha_mqtt_discoverable import Settings
+from ha_mqtt_discoverable.sensors import Valve, ValveInfo
+from paho.mqtt.client import Client, MQTTMessage
+
+# Configure the required parameters for the MQTT broker
+mqtt_settings = Settings.MQTT(host="localhost")
+
+# Information about the valve
+valve_info = ValveInfo(
+                name="test-position",
+                reports_position=True,
+                payload_open=None,
+                payload_close=None,
+                state_open=None,
+                state_closed=None,
+                )
+
+settings = Settings(mqtt=mqtt_settings, entity=valve_info)
+
+current_position = 0
+
+# To receive state commands from HA, define a callback function:
+def my_callback(client: Client, user_data, message: MQTTMessage):
+    payload = message.payload.decode()
+    # convert the payload of type str to int
+    try:
+        payload = int(payload)
+    except:
+        logger.error("Wrong payload")
+        return
+
+    if payload < my_valve.last_state:
+        # let HA know that the valve is closing
+        my_valve.position(my_valve.last_state, my_valve._entity.state_closing)
+    else:
+        # let HA know that the valve is closing
+        my_valve.position(my_valve.last_state, my_valve._entity.state_opening)
+    # call function to move the valve to the desired position
+    move_my_custom_valve(payload)
+    # Let HA know that the valve reached the desired position.
+    # In HA the positions 0 or 100 automatically show as closed
+    # or open respectivly, other positions should return to
+    # open, though this does not happen yet ([reported bug with pending fix](https://github.com/home-assistant/core/pull/165176).  
+    my_valve.position(payload)
+
+# Instantiate the valve
+my_valve = Valve(settings, my_callback)
+
+# Set the initial position of the valve, which also makes it discoverable
+my_valve.position(0)
+
 ```
 
 ## Availability Management

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Using MQTT discoverable devices lets us add new sensors and devices to HA withou
   - [Button](#button)
   - [Camera](#camera)
   - [Cover](#cover)
+  - [Device](#device)
   - [Device trigger](#device-trigger)
   - [Image](#image)
   - [Light](#light)
@@ -46,6 +47,7 @@ Using MQTT discoverable devices lets us add new sensors and devices to HA withou
 - [Contributors](#contributors)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 
 
 
@@ -216,6 +218,7 @@ my_cover = Cover(settings, my_callback)
 
 # Set the initial state of the cover, which also makes it discoverable
 my_cover.closed()
+```
 
 ### Device
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Using MQTT discoverable devices lets us add new sensors and devices to HA withou
 
 
 
+
 ## Installing
 
 ### Python
@@ -666,7 +667,11 @@ my_valve = Valve(settings, my_callback)
 my_valve.closed()
 ```
 #### Position command valve
-This mode is active when `reports_position = True`. The mode is different from other sensors as it can send a payload encoded/decoded as JSON, like the light device can. The valve can report two possible states `opening` and `closing`, a position (0-100) or a combination in JSON format, for example: `'{"state": "opening", "position": 42}'`. The command payload can be either `STOP` or a position (0-100). Note that in this mode payload_open, payload_close, state_open and state_closed must be set to None.
+This mode is active when `reports_position = True`. The mode is different from other sensors as it can send a payload encoded/decoded as JSON, like the light device can.
+
+The valve can report two possible states `opening` and `closing`, a position (0-100) or a combination in JSON format, for example: `'{"state": "opening", "position": 42}'`. The command payload can be either `STOP` or a position (0-100).
+
+Note that in this position mode, payload_open, payload_close, state_open and state_closed must be set to None.
 
 A `callback` function is needed in order to parse the commands sent from HA, as the following example shows:
 

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -230,6 +230,14 @@ class ValveInfo(EntityInfo):
             raise ValueError(
                 "payload_open, payload_close, state_open and state_closed should not be set when using reports_position."
             )
+
+        # Don't unset reports_position and payload_close, payload_open, state_open, state_closed at the same time.
+        if not self.reports_position and (
+            self.payload_open is None or self.payload_close is None or self.state_open is None or self.state_closed is None
+        ):
+            raise ValueError(
+                "payload_open, payload_close, state_open and state_closed should be set when not using reports_position."
+            )
         return self
 
 

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -631,7 +631,7 @@ class Valve(Subscriber[ValveInfo]):
         if not self._entity.reports_position:
             raise RuntimeError(f"Valve {self._entity.name} does not support position reporting")
         if not isinstance(position, int):
-            raise ValueError(f"Position should be an int not {type(position)}")
+            raise ValueError(f"Position for valve should be an int not {type(position)}")
         if position < 0 or position > 100:
             raise RuntimeError(f"Position for valve {self._entity.name} is out of range")
 

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -631,7 +631,7 @@ class Valve(Subscriber[ValveInfo]):
         self._update_state(self._entity.state_closing, retain=self._entity.retain)
 
     def opening(self) -> None:
-        """Set cover state to opening"""
+        """Set valve state to opening"""
         self._update_state(self._entity.state_opening, retain=self._entity.retain)
 
     def position(self, position: int, state: str | None = None) -> None:

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -220,13 +220,14 @@ class ValveInfo(EntityInfo):
         """
         Determine correct usage of configuration variables.
         """
-        # Don't set reports_position and payload_close or payload_open at the same time.
-        if self.reports_position:
-            self.payload_close = None
-            self.payload_open = None
-            self.state_closed = None
-            self.state_open = None
-            logger.warning(
+        # Don't set reports_position and payload_close, payload_open, state_open, state_closed at the same time.
+        if self.reports_position and (
+            self.payload_open is not None
+            or self.payload_close is not None
+            or self.state_open is not None
+            or self.state_closed is not None
+        ):
+            raise ValueError(
                 "payload_open, payload_close, state_open and state_closed should not be set when using reports_position."
             )
         return self

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -229,13 +229,6 @@ class ValveInfo(EntityInfo):
             logger.warning(
                 "payload_open, payload_close, state_open and state_closed should not be set when using reports_position."
             )
-            # if (not self.payload_open is None or
-            #     not self.payload_close is None or
-            #     not self.state_open is None or
-            #     not self.state_closed is None):
-            #     raise ValueError(
-            #         "payload_open, payload_close, state_open and state_closed should not be set when using reports_position."
-            #     )
         return self
 
 

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -641,9 +641,7 @@ class Valve(Subscriber[ValveInfo]):
         if position < 0 or position > 100:
             raise RuntimeError(f"Position for valve {self._entity.name} is out of range")
         if state and state not in [
-            self._entity.state_closed,
             self._entity.state_closing,
-            self._entity.state_open,
             self._entity.state_opening,
         ]:
             raise RuntimeError(f"State {state} does not match any of the configured states")

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -183,6 +183,57 @@ class CoverInfo(EntityInfo):
     """If the published message should have the retain flag on or not"""
 
 
+class ValveInfo(EntityInfo):
+    """Information about the MQTT valve entity"""
+
+    component: str = "valve"
+    """The MQTT component type for this entity."""
+
+    optimistic: bool | None = None
+    """Flag that defines if the valve works in optimistic mode.
+    Default: true if no state_topic defined, else false."""
+    payload_open: str | None = "OPEN"
+    """The payload that represents the open command."""
+    payload_close: str | None = "CLOSE"
+    """The payload that represents the close command."""
+    payload_stop: str | None = "STOP"
+    """The payload that represents the stop command."""
+    position_open: int = 100
+    """Number which represents fully open position."""
+    position_closed: int = 0
+    """Number which represents fully closed position."""
+    reports_position: bool = False
+    """Set to true if the valve reports or supports setting a position."""
+    state_open: str = "open"
+    """Payload that represents the open state."""
+    state_opening: str = "opening"
+    """Payload that represents the opening state."""
+    state_closed: str = "closed"
+    """Payload that represents the closed state."""
+    state_closing: str = "closing"
+    """Payload that represents the closing state."""
+    retain: bool = False
+    """If the published message should have the retain flag on or not"""
+
+    @model_validator(mode="after")
+    def valve_info_entity_model_validator(self) -> ValveInfo:
+        """
+        Determine correct usage of configuration variables.
+        """
+        # Don't set reports_position and payload_close or payload_open at the same time.
+        if self.reports_position:
+            self.payload_close = None
+            self.payload_open = None
+            self.state_closed = None
+            self.state_open = None
+        #         if  not self.payload_open is None or not self.payload_close is None:
+        #             raise ValueError(
+        #                 "payload_open and payload_close must be None when reports_position is True"
+        #             )
+
+        return self
+
+
 class ButtonInfo(EntityInfo):
     """Button specific information"""
 
@@ -547,6 +598,49 @@ class Cover(Subscriber[CoverInfo]):
     def stopped(self) -> None:
         """Set cover state to stopped"""
         self._update_state(self._entity.state_stopped, retain=self._entity.retain)
+
+
+class Valve(Subscriber[ValveInfo]):
+    """Implements an MQTT valve.
+    https://www.home-assistant.io/integrations/valve.mqtt
+    """
+
+    def open(self) -> None:
+        """Set valve state to open."""
+        if self._entity.reports_position:
+            self.set_position(100)
+        else:
+            self._update_state(self._entity.state_open, retain=self._entity.retain)
+
+    def closed(self) -> None:
+        """Set valve state to closed."""
+        if self._entity.reports_position:
+            self.set_position(0)
+        else:
+            self._update_state(self._entity.state_closed, retain=self._entity.retain)
+
+    def closing(self) -> None:
+        """Set valve state to closing."""
+        self._update_state(self._entity.state_closing, retain=self._entity.retain)
+
+    def opening(self) -> None:
+        """Set cover state to opening"""
+        self._update_state(self._entity.state_opening, retain=self._entity.retain)
+
+    def position(self, position: int, state: str | None = None) -> None:
+        """Set the valve to a desired position between 0 and 100."""
+        if not self._entity.reports_position:
+            raise RuntimeError(f"Valve {self._entity.name} does not support position reporting")
+        if not isinstance(position, int):
+            raise ValueError(f"Position should be an int not {type(position)}")
+        if position < 0 or position > 100:
+            raise RuntimeError(f"Position for valve {self._entity.name} is out of range")
+
+        if state is not None:
+            json_state = json.dumps({"state": state, "position": position})
+            self._update_state(json_state, retain=self._entity.retain)
+        else:
+            self._update_state(position, retain=self._entity.retain)
 
 
 class Button(Subscriber[ButtonInfo]):

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -226,11 +226,16 @@ class ValveInfo(EntityInfo):
             self.payload_open = None
             self.state_closed = None
             self.state_open = None
-        #         if  not self.payload_open is None or not self.payload_close is None:
-        #             raise ValueError(
-        #                 "payload_open and payload_close must be None when reports_position is True"
-        #             )
-
+            logger.warning(
+                "payload_open, payload_close, state_open and state_closed should not be set when using reports_position."
+            )
+            # if (not self.payload_open is None or
+            #     not self.payload_close is None or
+            #     not self.state_open is None or
+            #     not self.state_closed is None):
+            #     raise ValueError(
+            #         "payload_open, payload_close, state_open and state_closed should not be set when using reports_position."
+            #     )
         return self
 
 

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -640,12 +640,19 @@ class Valve(Subscriber[ValveInfo]):
             raise ValueError(f"Position for valve should be an int not {type(position)}")
         if position < 0 or position > 100:
             raise RuntimeError(f"Position for valve {self._entity.name} is out of range")
+        if state and state not in [
+            self._entity.state_closed,
+            self._entity.state_closing,
+            self._entity.state_open,
+            self._entity.state_opening,
+        ]:
+            raise RuntimeError(f"State {state} does not match any of the configured states")
 
-        if state is not None:
+        if state is None:
+            self._update_state(position, retain=self._entity.retain)
+        else:
             json_state = json.dumps({"state": state, "position": position})
             self._update_state(json_state, retain=self._entity.retain)
-        else:
-            self._update_state(position, retain=self._entity.retain)
 
 
 class Button(Subscriber[ButtonInfo]):

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -204,11 +204,11 @@ class ValveInfo(EntityInfo):
     """Number which represents fully closed position."""
     reports_position: bool = False
     """Set to true if the valve reports or supports setting a position."""
-    state_open: str = "open"
+    state_open: str | None = "open"
     """Payload that represents the open state."""
     state_opening: str = "opening"
     """Payload that represents the opening state."""
-    state_closed: str = "closed"
+    state_closed: str | None = "closed"
     """Payload that represents the closed state."""
     state_closing: str = "closing"
     """Payload that represents the closing state."""
@@ -613,14 +613,14 @@ class Valve(Subscriber[ValveInfo]):
     def open(self) -> None:
         """Set valve state to open."""
         if self._entity.reports_position:
-            self.set_position(100)
+            self.position(100)
         else:
             self._update_state(self._entity.state_open, retain=self._entity.retain)
 
     def closed(self) -> None:
         """Set valve state to closed."""
         if self._entity.reports_position:
-            self.set_position(0)
+            self.position(0)
         else:
             self._update_state(self._entity.state_closed, retain=self._entity.retain)
 

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -189,9 +189,8 @@ class ValveInfo(EntityInfo):
     component: str = "valve"
     """The MQTT component type for this entity."""
 
-    optimistic: bool | None = None
-    """Flag that defines if the valve works in optimistic mode.
-    Default: true if no state_topic defined, else false."""
+    optimistic: bool = False
+    """Flag that defines if the valve works in optimistic mode."""
     payload_open: str | None = "OPEN"
     """The payload that represents the open command."""
     payload_close: str | None = "CLOSE"

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -233,7 +233,7 @@ class ValveInfo(EntityInfo):
 
         # Don't unset reports_position and payload_close, payload_open, state_open, state_closed at the same time.
         if not self.reports_position and (
-            self.payload_open is None or self.payload_close is None or self.state_open is None or self.state_closed is None
+            self.state_open is None or self.state_closed is None
         ):
             raise ValueError(
                 "payload_open, payload_close, state_open and state_closed should be set when not using reports_position."

--- a/ha_mqtt_discoverable/sensors.py
+++ b/ha_mqtt_discoverable/sensors.py
@@ -232,9 +232,7 @@ class ValveInfo(EntityInfo):
             )
 
         # Don't unset reports_position and payload_close, payload_open, state_open, state_closed at the same time.
-        if not self.reports_position and (
-            self.state_open is None or self.state_closed is None
-        ):
+        if not self.reports_position and (self.state_open is None or self.state_closed is None):
             raise ValueError(
                 "payload_open, payload_close, state_open and state_closed should be set when not using reports_position."
             )

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -119,6 +119,11 @@ def test_position_and_state(position_valve: Valve):
         mock_publish.assert_called_with(position_valve.state_topic, '{"state": "opening", "position": 42}', retain=False)
 
 
+def test_position_and_wrong_state(position_valve: Valve):
+    with pytest.raises(RuntimeError, match="does not match any of the configured states"):
+        position_valve.position(42, "wrong_state")  # type: ignore[arg-type]
+
+
 def test_reports_position_true_disable_payload_and_state_fields():
     """When reports_position=True, payload_* and state_* must be None (HA restriction)."""
     with pytest.raises(

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -103,7 +103,7 @@ def test_set_position_out_of_range(position_valve: Valve, position: int):
 
 def test_set_position_as_non_int(position_valve: Valve):
     with pytest.raises(ValueError, match="Position should be an int not"):
-        position_valve.position("50")
+        position_valve.position("50")  # type: ignore[arg-type]
 
 
 def test_set_position_not_supported(valve: Valve):

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -18,21 +18,40 @@ from ha_mqtt_discoverable.sensors import Valve, ValveInfo
 
 
 @pytest.fixture
-def valve() -> Valve:
-    """Return a valve instance"""
-    mqtt_settings = Settings.MQTT(host="localhost")
-    valve_info = ValveInfo(name="test")
-    settings = Settings(mqtt=mqtt_settings, entity=valve_info)
-    return Valve(settings, lambda _, __, ___: None)
+def make_valve():
+    def _make_valve(
+        reports_position: bool = False,
+        payload_open: str | None = "OPEN",
+        payload_close: str | None = "CLOSE",
+        state_open: str | None = "open",
+        state_closed: str | None = "closed",
+    ):
+        """Return a valve instance"""
+        mqtt_settings = Settings.MQTT(host="localhost")
+        sensor_info = ValveInfo(
+            name="test",
+            reports_position=reports_position,
+            payload_open=payload_open,
+            payload_close=payload_close,
+            state_open=state_open,
+            state_closed=state_closed,
+        )
+        settings = Settings(mqtt=mqtt_settings, entity=sensor_info)
+        return Valve(settings, lambda _, __, ___: None)
+
+    return _make_valve
 
 
 @pytest.fixture
-def position_valve() -> Valve:
+def valve(make_valve) -> Valve:
+    """Return a valve instance"""
+    return make_valve()
+
+
+@pytest.fixture
+def position_valve(make_valve) -> Valve:
     """Return a valve instance that is position controlled"""
-    mqtt_settings = Settings.MQTT(host="localhost")
-    valve_info = ValveInfo(name="test", reports_position=True)
-    settings = Settings(mqtt=mqtt_settings, entity=valve_info)
-    return Valve(settings, lambda _, __, ___: None)
+    return make_valve(reports_position=True, payload_open=None, payload_close=None, state_open=None, state_closed=None)
 
 
 def test_required_config():
@@ -80,19 +99,17 @@ def test_position_and_state(position_valve: Valve):
 
 def test_reports_position_true_disables_payload_and_state_fields():
     """When reports_position=True, payload_* and state_* must be None (HA restriction)."""
-    valve_info = ValveInfo(
-        name="test",
-        reports_position=True,
-        payload_open="OPEN",
-        payload_close="CLOSE",
-        state_open="open",
-        state_closed="closed",
-    )
-
-    assert valve_info.payload_open is None
-    assert valve_info.payload_close is None
-    assert valve_info.state_open is None
-    assert valve_info.state_closed is None
+    with pytest.raises(
+        ValueError, match="payload_open, payload_close, state_open and state_closed should not be set when using reports_position."
+    ):
+        ValveInfo(
+            name="test",
+            reports_position=True,
+            payload_open="OPEN",
+            payload_close="CLOSE",
+            state_open="open",
+            state_closed="closed",
+        )
 
 
 @pytest.mark.parametrize("position", [-1, 101])

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -65,41 +65,59 @@ def test_required_config():
     assert valve is not None
 
 
-def test_open(valve: Valve, position_valve: Valve):
+# Test state command valve
+def test_open_state_valve(valve: Valve):
     """Test to set a valve to open"""
     with patch.object(valve.mqtt_client, "publish") as mock_publish:
         valve.open()
         mock_publish.assert_called_with(valve.state_topic, valve._entity.state_open, retain=False)
+
+
+def test_closed_state_valve(valve: Valve):
+    """Test to set a valve to closed"""
+    with patch.object(valve.mqtt_client, "publish") as mock_publish:
+        valve.closed()
+        mock_publish.assert_called_with(valve.state_topic, valve._entity.state_closed, retain=False)
+
+
+def test_closing_state_valve(valve: Valve):
+    """Test to set a valve to closing"""
+    with patch.object(valve.mqtt_client, "publish") as mock_publish:
+        valve.closing()
+        mock_publish.assert_called_with(valve.state_topic, valve._entity.state_closing, retain=False)
+
+
+def test_opening_state_valve(valve: Valve):
+    """Test to set a valve to opening"""
+    with patch.object(valve.mqtt_client, "publish") as mock_publish:
+        valve.opening()
+        mock_publish.assert_called_with(valve.state_topic, valve._entity.state_opening, retain=False)
+
+
+# Test position command valve
+def test_open_position_valve(position_valve: Valve):
+    """Test to set a valve to open"""
     with patch.object(position_valve.mqtt_client, "publish") as mock_publish:
         position_valve.open()
         mock_publish.assert_called_with(position_valve.state_topic, position_valve._entity.position_open, retain=False)
 
 
-def test_closed(valve: Valve, position_valve: Valve):
+def test_closed_position_valve(position_valve: Valve):
     """Test to set a valve to closed"""
-    with patch.object(valve.mqtt_client, "publish") as mock_publish:
-        valve.closed()
-        mock_publish.assert_called_with(valve.state_topic, valve._entity.state_closed, retain=False)
     with patch.object(position_valve.mqtt_client, "publish") as mock_publish:
         position_valve.closed()
         mock_publish.assert_called_with(position_valve.state_topic, position_valve._entity.position_closed, retain=False)
 
 
-def test_closing(valve: Valve, position_valve: Valve):
+def test_closing_position_valve(position_valve: Valve):
     """Test to set a valve to closing"""
-    with patch.object(valve.mqtt_client, "publish") as mock_publish:
-        valve.closing()
-        mock_publish.assert_called_with(valve.state_topic, valve._entity.state_closing, retain=False)
     with patch.object(position_valve.mqtt_client, "publish") as mock_publish:
         position_valve.closing()
         mock_publish.assert_called_with(position_valve.state_topic, position_valve._entity.state_closing, retain=False)
 
 
-def test_opening(valve: Valve, position_valve: Valve):
+def test_opening_position_valve(position_valve: Valve):
     """Test to set a valve to opening"""
-    with patch.object(valve.mqtt_client, "publish") as mock_publish:
-        valve.opening()
-        mock_publish.assert_called_with(valve.state_topic, valve._entity.state_opening, retain=False)
     with patch.object(position_valve.mqtt_client, "publish") as mock_publish:
         position_valve.opening()
         mock_publish.assert_called_with(position_valve.state_topic, position_valve._entity.state_opening, retain=False)

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -141,7 +141,7 @@ def test_set_position_out_of_range(position_valve: Valve, position: int):
 
 
 def test_set_position_as_non_int(position_valve: Valve):
-    with pytest.raises(ValueError, match="Position should be an int not"):
+    with pytest.raises(ValueError, match="Position for valve should be an int not"):
         position_valve.position("50")  # type: ignore[arg-type]
 
 

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -1,0 +1,85 @@
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+import pytest
+
+from ha_mqtt_discoverable import Settings
+from ha_mqtt_discoverable.sensors import Valve, ValveInfo
+
+
+@pytest.fixture
+def valve() -> Valve:
+    """Return a valve instance"""
+    mqtt_settings = Settings.MQTT(host="localhost")
+    valve_info = ValveInfo(name="test")
+    settings = Settings(mqtt=mqtt_settings, entity=valve_info)
+    return Valve(settings, lambda _, __, ___: None)
+
+
+@pytest.fixture
+def position_valve() -> Valve:
+    """Return a valve instance that is position controlled"""
+    mqtt_settings = Settings.MQTT(host="localhost")
+    valve_info = ValveInfo(name="test", reports_position=True)
+    settings = Settings(mqtt=mqtt_settings, entity=valve_info)
+    return Valve(settings, lambda _, __, ___: None)
+
+
+def test_required_config():
+    """Test to make sure a valve instance can be created"""
+    mqtt_settings = Settings.MQTT(host="localhost")
+    valve_info = ValveInfo(name="test")
+    settings = Settings(mqtt=mqtt_settings, entity=valve_info)
+    valve = Valve(settings, lambda _, __, ___: None)
+    assert valve is not None
+
+
+def test_open(valve: Valve):
+    """Test to set a valve to open"""
+    valve.open()
+
+
+def test_closed(valve: Valve):
+    """Test to set a valve to closed"""
+    valve.closed()
+
+
+def test_closing(valve: Valve):
+    """Test to set a valve to closing"""
+    valve.closing()
+
+
+def test_opening(valve: Valve):
+    """Test to set a valve to opening"""
+    valve.opening()
+
+
+def test_position(position_valve: Valve):
+    """Test to set a position to the valve"""
+    position_valve.position(42)
+
+
+def test_position_and_state(position_valve: Valve):
+    """Test to set a position and state to the valve"""
+    position_valve.position(state="opening", position=42)
+
+
+@pytest.mark.parametrize("position", [-1, 101])
+def test_set_position_out_of_range(position_valve: Valve, position: int):
+    with pytest.raises(RuntimeError, match="out of range"):
+        position_valve.position(position)
+
+
+def test_set_position_not_supported(valve: Valve):
+    with pytest.raises(RuntimeError, match="does not support position reporting"):
+        valve.position(50)

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -119,7 +119,7 @@ def test_position_and_state(position_valve: Valve):
         mock_publish.assert_called_with(position_valve.state_topic, '{"state": "opening", "position": 42}', retain=False)
 
 
-def test_reports_position_true_disables_payload_and_state_fields():
+def test_reports_position_true_disable_payload_and_state_fields():
     """When reports_position=True, payload_* and state_* must be None (HA restriction)."""
     with pytest.raises(
         ValueError, match="payload_open, payload_close, state_open and state_closed should not be set when using reports_position."
@@ -131,6 +131,21 @@ def test_reports_position_true_disables_payload_and_state_fields():
             payload_close="CLOSE",
             state_open="open",
             state_closed="closed",
+        )
+
+
+def test_reports_position_false_enable_payload_and_state_fields():
+    """When reports_position=False, payload_* and state_* must be set for convenient use."""
+    with pytest.raises(
+        ValueError, match="payload_open, payload_close, state_open and state_closed should be set when not using reports_position."
+    ):
+        ValveInfo(
+            name="test",
+            reports_position=False,
+            payload_open=None,
+            payload_close=None,
+            state_open=None,
+            state_closed=None,
         )
 
 

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -11,6 +11,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+from unittest.mock import patch
+
 import pytest
 
 from ha_mqtt_discoverable import Settings
@@ -65,36 +67,56 @@ def test_required_config():
 
 def test_open(valve: Valve, position_valve: Valve):
     """Test to set a valve to open"""
-    valve.open()
-    position_valve.open()
+    with patch.object(valve.mqtt_client, "publish") as mock_publish:
+        valve.open()
+        mock_publish.assert_called_with(valve.state_topic, valve._entity.state_open, retain=False)
+    with patch.object(position_valve.mqtt_client, "publish") as mock_publish:
+        position_valve.open()
+        mock_publish.assert_called_with(position_valve.state_topic, position_valve._entity.position_open, retain=False)
 
 
 def test_closed(valve: Valve, position_valve: Valve):
     """Test to set a valve to closed"""
-    valve.closed()
-    position_valve.closed()
+    with patch.object(valve.mqtt_client, "publish") as mock_publish:
+        valve.closed()
+        mock_publish.assert_called_with(valve.state_topic, valve._entity.state_closed, retain=False)
+    with patch.object(position_valve.mqtt_client, "publish") as mock_publish:
+        position_valve.closed()
+        mock_publish.assert_called_with(position_valve.state_topic, position_valve._entity.position_closed, retain=False)
 
 
 def test_closing(valve: Valve, position_valve: Valve):
     """Test to set a valve to closing"""
-    valve.closing()
-    position_valve.closing()
+    with patch.object(valve.mqtt_client, "publish") as mock_publish:
+        valve.closing()
+        mock_publish.assert_called_with(valve.state_topic, valve._entity.state_closing, retain=False)
+    with patch.object(position_valve.mqtt_client, "publish") as mock_publish:
+        position_valve.closing()
+        mock_publish.assert_called_with(position_valve.state_topic, position_valve._entity.state_closing, retain=False)
 
 
 def test_opening(valve: Valve, position_valve: Valve):
     """Test to set a valve to opening"""
-    valve.opening()
-    position_valve.opening()
+    with patch.object(valve.mqtt_client, "publish") as mock_publish:
+        valve.opening()
+        mock_publish.assert_called_with(valve.state_topic, valve._entity.state_opening, retain=False)
+    with patch.object(position_valve.mqtt_client, "publish") as mock_publish:
+        position_valve.opening()
+        mock_publish.assert_called_with(position_valve.state_topic, position_valve._entity.state_opening, retain=False)
 
 
 def test_position(position_valve: Valve):
     """Test to set a position to the valve"""
-    position_valve.position(42)
+    with patch.object(position_valve.mqtt_client, "publish") as mock_publish:
+        position_valve.position(42)
+        mock_publish.assert_called_with(position_valve.state_topic, 42, retain=False)
 
 
 def test_position_and_state(position_valve: Valve):
     """Test to set a position and state to the valve"""
-    position_valve.position(state="opening", position=42)
+    with patch.object(position_valve.mqtt_client, "publish") as mock_publish:
+        position_valve.position(42, "opening")
+        mock_publish.assert_called_with(position_valve.state_topic, '{"state": "opening", "position": 42}', retain=False)
 
 
 def test_reports_position_true_disables_payload_and_state_fields():

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -44,24 +44,28 @@ def test_required_config():
     assert valve is not None
 
 
-def test_open(valve: Valve):
+def test_open(valve: Valve, position_valve: Valve):
     """Test to set a valve to open"""
     valve.open()
+    position_valve.open()
 
 
-def test_closed(valve: Valve):
+def test_closed(valve: Valve, position_valve: Valve):
     """Test to set a valve to closed"""
     valve.closed()
+    position_valve.closed()
 
 
-def test_closing(valve: Valve):
+def test_closing(valve: Valve, position_valve: Valve):
     """Test to set a valve to closing"""
     valve.closing()
+    position_valve.closing()
 
 
-def test_opening(valve: Valve):
+def test_opening(valve: Valve, position_valve: Valve):
     """Test to set a valve to opening"""
     valve.opening()
+    position_valve.opening()
 
 
 def test_position(position_valve: Valve):
@@ -74,10 +78,32 @@ def test_position_and_state(position_valve: Valve):
     position_valve.position(state="opening", position=42)
 
 
+def test_reports_position_true_disables_payload_and_state_fields():
+    """When reports_position=True, payload_* and state_* must be None (HA restriction)."""
+    valve_info = ValveInfo(
+        name="test",
+        reports_position=True,
+        payload_open="OPEN",
+        payload_close="CLOSE",
+        state_open="open",
+        state_closed="closed",
+    )
+
+    assert valve_info.payload_open is None
+    assert valve_info.payload_close is None
+    assert valve_info.state_open is None
+    assert valve_info.state_closed is None
+
+
 @pytest.mark.parametrize("position", [-1, 101])
 def test_set_position_out_of_range(position_valve: Valve, position: int):
     with pytest.raises(RuntimeError, match="out of range"):
         position_valve.position(position)
+
+
+def test_set_position_as_non_int(position_valve: Valve):
+    with pytest.raises(ValueError, match="Position should be an int not"):
+        position_valve.position("50")
 
 
 def test_set_position_not_supported(valve: Valve):

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -121,7 +121,7 @@ def test_position_and_state(position_valve: Valve):
 
 def test_position_and_wrong_state(position_valve: Valve):
     with pytest.raises(RuntimeError, match="does not match any of the configured states"):
-        position_valve.position(42, "wrong_state")  # type: ignore[arg-type]
+        position_valve.position(42, "wrong_state")
 
 
 def test_reports_position_true_disable_payload_and_state_fields():


### PR DESCRIPTION
<!-- DOCTOC SKIP -->
# Description

This PR adds basic support for the Home Assistant MQTT valve integration to ha-mqtt-discoverable.
The implementation follows the Home Assistant MQTT valve specification and supports both:

- State‑based valves (open, closed, opening, closing, stop)
- Position‑controlled valves (0–100) via reports_position=True

The change is fully backward‑compatible and does not affect existing entities.

What’s included:

- New ValveInfo entity definition with validation logic
- New Valve sensor implementation
- Support for:
  - open / close / stop commands
  - optional position reporting
  - JSON state + position payloads where applicable
- Unit tests
- Documentation update in README.md with usage examples (for state and position commands)

For the pydantic model validator I proposed two option: 
- Fix mis configuration (my preference to ease configuring a valve)
- Raise a value error (probably most in line with the HMD implementation) 

P.s My first PR on github, feedback is welkom. 

<!-- Describe your changes in detail -->

## Credit
No explicit need to mention me, though if convenient please refer to me on GitHub: @jvanoosterhout

## License Acceptance

-  [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

## Developer Certificate of Origin (DCO)

The Developer Certificate of Origin (DCO) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project. Here is the full text of the DCO, reformatted for readability:

```text
By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have
the right to submit it under the open source license indicated in the
file; or

(b) The contribution is based upon previous work that, to the best of
 my knowledge, is covered under an appropriate open source license and
 I have the right under that license to submit that work with
 modifications, whether created in whole or in part by me, under the
 same open source license (unless I am permitted to submit under a
 different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person
who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are
public and that a record of the contribution (including all personal
information I submit with it, including my sign-off) is maintained
indefinitely and may be redistributed consistent with this project or
the open source license(s) involved.
```

Contributors sign-off that they adhere to these requirements by adding a `Signed-off-by` line to commit messages.

```text
This is my commit message

Signed-off-by: Random J Developer <random@developer.example.org>
```

Git even has a `-s` command line option to append this automatically to your commit message:

```sh
git commit -s -m 'This is my commit message'
```

## Type of changes

<!-- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [x] New feature
- [ ] Test updates
- [ ] Text cleanups/updates
- [ ] New release to PyPi
- [ ] Documentation update

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] I have signed off my commits per the DCO
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR *do not* have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any links added or updated in my PR are valid.
