### PR TITLE
Update README with MQTT authentication example

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ from ha_mqtt_discoverable.sensors import BinarySensor, BinarySensorInfo
 
 # Configure the required parameters for the MQTT broker
 mqtt_settings = Settings.MQTT(host="localhost")
+# or use authentication
+mqtt_settings = Settings.MQTT(host="some.server", username="someuser", password="somepassword")
 
 # Information about the sensor
 sensor_info = BinarySensorInfo(name="MySensor", device_class="motion")

--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ ha-mqtt-discoverable runs on Python 3.10 or later.
 `pip install ha-mqtt-discoverable` if you want to use it in your own Python scripts.
 
 <!-- Please keep the entities in alphabetical order -->
+
+## Connecting
+Configuring a connection is straightforward, with or without authentication.
+
+```py
+from ha_mqtt_discoverable import Settings
+
+# Configure the required parameters for the MQTT broker (without authentication)
+mqtt_settings = Settings.MQTT(host="localhost")
+# ..or configure the required parameters for the MQTT broker (with authentication)
+mqtt_settings = Settings.MQTT(host="some.server", username="someuser", password="somepassword")
+```
+Settings that provide authentication can be used as a drop-in replacement for any of the examples below.
+
 ## Supported entities
 
 The following Home Assistant entities are currently implemented:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ mqtt_settings = Settings.MQTT(host="localhost")
 # ..or configure the required parameters for the MQTT broker (with authentication)
 mqtt_settings = Settings.MQTT(host="some.server", username="someuser", password="somepassword")
 ```
+
+The connection is automatically established when an action is taken by an 
 Settings that provide authentication can be used as a drop-in replacement for any of the examples below.
+
 
 ## Supported entities
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ mqtt_settings = Settings.MQTT(host="localhost")
 mqtt_settings = Settings.MQTT(host="some.server", username="someuser", password="somepassword")
 ```
 
-The connection is automatically established when an action is taken by an
-Settings that provide authentication can be used as a drop-in replacement for any of the examples below.
+The connection is automatically established when needed by an entity using these settings.
+
+MQTT Settings that provide authentication can be used as a drop-in replacement in any of the examples below.
 
 
 ## Supported entities

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Using MQTT discoverable devices lets us add new sensors and devices to HA withou
 
 - [Installing](#installing)
   - [Python](#python)
+- [Connecting](#connecting)
 - [Supported entities](#supported-entities)
   - [Binary sensor](#binary-sensor)
   - [Button](#button)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ mqtt_settings = Settings.MQTT(host="localhost")
 mqtt_settings = Settings.MQTT(host="some.server", username="someuser", password="somepassword")
 ```
 
-The connection is automatically established when an action is taken by an 
+The connection is automatically established when an action is taken by an
 Settings that provide authentication can be used as a drop-in replacement for any of the examples below.
 
 


### PR DESCRIPTION
Added example for MQTT broker authentication in README.

<!-- DOCTOC SKIP -->
# Description
Adds an authentication example.

<!-- Describe your changes in detail -->

## Credit
<!-- Releases are announced on Mastodon. In order for me to credit people properly, -->
<!-- if you have a mastodon account, please put it here to have it mentioned in the -->
<!-- release announcement. If there's another way you want to be credited, please   -->
<!-- add details here. -->

## License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

## Developer Certificate of Origin (DCO)
I agree with the DCO.

## Type of changes

<!-- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Bug fix
- [ ] New feature
- [ ] Test updates
- [ ] Text cleanups/updates
- [ ] New release to PyPi
- [x] Documentation update

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!-- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [ ] I have read the [CONTRIBUTING](https://github.com/unixorn/ha-mqtt-discovery/blob/main/Contributing.md) document.
- [x] I have signed off my commits per the DCO - I believe this was done automatically via github when I clicked "sign off"
- [x] All new and existing tests pass (as long as they did before this commit, they still will)
- [x] Agreements irrelevant to this PR have been removed
